### PR TITLE
updated styling on document records table

### DIFF
--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcros-documents-ui",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {
@@ -27,6 +27,8 @@
     "http-status-codes": "^2.1.4",
     "keycloak-js": "^24.0.4",
     "launchdarkly-vue-client-sdk": "^2.2.0",
+    "lodash": "^4.17.21",
+    "lodash.debounce": "^4.0.8",
     "nuxt": "^3.12.4",
     "sass": "^1.77.3",
     "v-calendar": "^3.1.2",

--- a/document-service/documents-ui/pnpm-lock.yaml
+++ b/document-service/documents-ui/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
       launchdarkly-vue-client-sdk:
         specifier: ^2.2.0
         version: 2.2.0(vue@3.4.33(typescript@5.5.4))
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      lodash.debounce:
+        specifier: ^4.0.8
+        version: 4.0.8
       nuxt:
         specifier: ^3.12.4
         version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.14.12)(eslint@9.7.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.4)(rollup@4.19.0)(sass@1.77.8)(terser@5.31.3)(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.12)(sass@1.77.8)(terser@5.31.3))
@@ -3516,6 +3522,9 @@ packages:
 
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -9390,6 +9399,8 @@ snapshots:
       p-locate: 6.0.0
 
   lodash.castarray@4.4.0: {}
+
+  lodash.debounce@4.0.8: {}
 
   lodash.defaults@4.2.0: {}
 

--- a/document-service/documents-ui/src/app.config.ts
+++ b/document-service/documents-ui/src/app.config.ts
@@ -78,8 +78,13 @@ export default defineAppConfig({
     },
     selectMenu: {
       option: {
-        base: 'cursor-pointer',
+        base: 'cursor-pointer h-[44px]',
       },
+      popper: {
+        placement: 'bottom-start',
+        offsetDistance: 0
+      },
+      padding: 'p-0'
     },
     modal: {
       overlay: {
@@ -94,7 +99,7 @@ export default defineAppConfig({
       background: 'bg-gray-700'
     },
     table: {
-      wrapper: 'max-h-[500px] overflow-y-auto overflow-x-auto',
+      wrapper: 'max-h-[700px] min-h-[250px] overflow-y-auto overflow-x-auto',
       thead: 'sticky top-0 bg-white z-10',
       th: {
         base: 'text-left text-gray-700 font-bold whitespace-nowrap',

--- a/document-service/documents-ui/src/app.config.ts
+++ b/document-service/documents-ui/src/app.config.ts
@@ -16,7 +16,7 @@ export default defineAppConfig({
     },
     input: {
       base: 'relative text-gray-900 border-0 border-b-[1px] border-gray-500 ring-0 focus:ring-0 ' +
-        'disabled:cursor-not-allowed disabled:opacity-45'
+        'disabled:cursor-not-allowed disabled:opacity-45 rounded'
     },
     textarea: {
       base: 'text-gray-900 border-0 border-b-[1px] border-gray-500 ring-0 focus:ring-0 h-[125px]',
@@ -86,6 +86,13 @@ export default defineAppConfig({
         background: 'bg-gray-900/75',
       }
     },
+    button: {
+      base: 'rounded'
+    },
+    tooltip: {
+      base: 'whitespace-normal h-auto p-3 bg-gray-700',
+      background: 'bg-gray-700'
+    },
     table: {
       wrapper: 'max-h-[500px] overflow-y-auto overflow-x-auto',
       thead: 'sticky top-0 bg-white z-10',
@@ -94,7 +101,7 @@ export default defineAppConfig({
         padding: "px-0"
       },
       td: {
-        base: 'max-w-[200px] align-top h-[65px] last:flex last:justify-center whitespace-normal',
+        base: 'align-top h-[65px] last:flex last:justify-center whitespace-normal',
         color: 'text-gray-700',
       }
     }

--- a/document-service/documents-ui/src/assets/styles/base.scss
+++ b/document-service/documents-ui/src/assets/styles/base.scss
@@ -97,6 +97,17 @@ body {
   th {
     @apply text-gray-900 text-sm
   }
+
+  div[data-cy="document-management"] table th:last-child,
+  div[data-cy="document-management"] table td:last-child {
+    display: table-cell;
+    position: sticky;
+    right: 0;
+    width: 156px;
+    max-width: 156px;
+    min-width: 156px;
+    padding: 0
+  }
 }
 
 .border-error-left {

--- a/document-service/documents-ui/src/components/InputDatePicker/index.vue
+++ b/document-service/documents-ui/src/components/InputDatePicker/index.vue
@@ -78,6 +78,7 @@ const datePlaceholder = computed(() => {
           :padded="false"
           @click="emit('update:modelValue', null)"
         />
+        <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5"/>
       </template>
     </UInput>
 

--- a/document-service/documents-ui/src/components/InputMultiSelector/index.vue
+++ b/document-service/documents-ui/src/components/InputMultiSelector/index.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+const props = defineProps({
+  options: {
+    type: Array as PropType<any>,
+    required: true,
+  },
+  valueAttribute: {
+    type: String,
+    required: true,
+  },
+  optionAttribute: {
+    type: String,
+    required: true,
+  },
+  label: {
+    type: String,
+    required: false,
+    default: "",
+  },
+})
+const emit = defineEmits(["changeColumns"])
+
+const selected = ref([])
+
+onMounted(() => {
+  try {
+    selected.value = props.options.map((option) => option[props.valueAttribute])
+  } catch (error) {
+    console.error(error)
+  }
+})
+</script>
+<template>
+  <USelectMenu
+    v-model="selected"
+    class="text-gray-700 text-light"
+    :placeholder="label"
+    :options="options"
+    :value-attribute="valueAttribute"
+    :option-attribute="optionAttribute"
+    size="md"
+    multiple
+    :popper="{ placement: 'bottom-start' }"
+    :ui="{
+      icon: { trailing: { pointer: '' } },
+      size: { md: 'h-[44px]' },
+    }"
+    trailing-icon="i-mdi-arrow-drop-down"
+    @change="emit('changeColumns', selected)"
+  >
+    <template v-if="label" #label>
+      <span>{{ $t("documentSearch.table.headers.columnsToShow") }}</span>
+    </template>
+    <template #option="optionProps">
+      <UCheckbox
+        v-model="optionProps.selected"
+        :name="optionProps.option[valueAttribute]"
+        :label="optionProps.option[optionAttribute]"
+      />
+    </template>
+  </USelectMenu>
+</template>

--- a/document-service/documents-ui/src/components/InputMultiSelector/index.vue
+++ b/document-service/documents-ui/src/components/InputMultiSelector/index.vue
@@ -40,7 +40,6 @@ onMounted(() => {
     :option-attribute="optionAttribute"
     size="md"
     multiple
-    :popper="{ placement: 'bottom-start' }"
     :ui="{
       icon: { trailing: { pointer: '' } },
       size: { md: 'h-[44px]' },

--- a/document-service/documents-ui/src/components/documentsTable/downloadLink.vue
+++ b/document-service/documents-ui/src/components/documentsTable/downloadLink.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { truncate } from "~/utils/documentRecords"
+const {
+  downloadFileFromUrl,
+} = useDocuments()
+
+defineProps({
+  downloadUrl: {
+    type: String,
+    required: true
+  },
+  fileName: {
+    type: String,
+    required: true
+  }
+})
+
+</script>
+<template>
+  <ULink
+    inactive-class="text-primary"
+    class="flex align-center"
+    @click="downloadFileFromUrl(downloadUrl, fileName)"
+  >
+      <UTooltip
+        :popper="{ placement: 'bottom' }"
+        :text="fileName"
+      >
+      <UIcon name="i-mdi-file-download" class="w-5 h-5" />
+      {{ truncate(fileName, 15, 6, 6) }}
+      </UTooltip>
+  </ULink>
+</template>

--- a/document-service/documents-ui/src/components/documentsTable/downloadLink.vue
+++ b/document-service/documents-ui/src/components/documentsTable/downloadLink.vue
@@ -23,11 +23,16 @@ defineProps({
     @click="downloadFileFromUrl(downloadUrl, fileName)"
   >
       <UTooltip
+        v-if="fileName.length > 15"
         :popper="{ placement: 'bottom' }"
         :text="fileName"
       >
-      <UIcon name="i-mdi-file-download" class="w-5 h-5" />
+      <UIcon name="i-mdi-file-download mr-1.5" class="w-5 h-5" />
       {{ truncate(fileName, 15, 6, 6) }}
       </UTooltip>
+      <template v-else>
+        <UIcon name="i-mdi-file-download mr-1.5" class="w-5 h-5" />
+        {{ fileName }}
+      </template>
   </ULink>
 </template>

--- a/document-service/documents-ui/src/components/documentsTable/index.vue
+++ b/document-service/documents-ui/src/components/documentsTable/index.vue
@@ -89,7 +89,7 @@ onBeforeUnmount(() => {
 <template>
   <ContentWrapper
     name="document-search-results"
-    class="my-12"
+    class="mt-8 mb-12"
     data-cy="document-search-results"
     :is-table="true"
   >
@@ -100,27 +100,34 @@ onBeforeUnmount(() => {
           ({{ searchResultCount || 0 }})
         </span>
         <div class="flex gap-4">
-          <span>
-            <USelectMenu
-              v-model="searchEntityType"
-              :placeholder="$t('documentSearch.form.selectMenu.categoryLabel')"
-              class="text-gray-700 text-light w-[300px]"
-              :options="documentTypes"
-              value-attribute="class"
-              option-attribute="description"
-              size="md"
-              :popper="{ placement: 'bottom-start' }"
-              :ui="{
-                icon: { trailing: { pointer: '' } },
-                size: { md: 'h-[44px]' },
-              }"
-              trailing-icon="i-mdi-arrow-drop-down"
-            />
-          </span>
-
+          <USelectMenu
+            v-model="searchEntityType"
+            :placeholder="$t('documentSearch.table.headers.entityType')"
+            class="text-gray-700 font-light w-[300px]"
+            :options="documentTypes"
+            value-attribute="class"
+            option-attribute="description"
+            size="md"
+            :ui="{
+              icon: { trailing: { pointer: '' } },
+              size: { md: 'h-[44px]' },
+            }"
+            :ui-menu="{ height: 'max-h-65 h-[355px]' }"
+          >
+            <template #trailing>
+              <UButton
+                v-show="searchEntityType !== ''"
+                variant="link"
+                icon="i-mdi-cancel-circle text-primary"
+                :padded="false"
+                @click="searchEntityType = ''"
+              />
+              <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5 text-gray-700  " />
+            </template>
+          </USelectMenu>
           <InputMultiSelector
             :options="documentResultColumns.filter((column) => !column.isFixed)"
-            class="w-[250px]"
+            class="w-[250px] font-light"
             value-attribute="key"
             option-attribute="label"
             :label="$t('documentSearch.table.headers.columnsToShow')"
@@ -187,7 +194,6 @@ onBeforeUnmount(() => {
                 value-attribute="type"
                 option-attribute="description"
                 size="md"
-                :popper="{ placement: 'bottom-start' }"
                 :ui="{
                   icon: { trailing: { pointer: '' } },
                   size: { md: 'h-[44px]' },
@@ -196,13 +202,12 @@ onBeforeUnmount(() => {
                 <template #trailing>
                   <UButton
                     v-show="searchDocumentType !== ''"
-                    color="gray"
                     variant="link"
                     icon="i-mdi-cancel-circle text-primary"
                     :padded="false"
                     @click="searchDocumentType = ''"
                   />
-                  <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5" />
+                  <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5 " />
                 </template>
               </USelectMenu>
             </div>
@@ -233,10 +238,8 @@ onBeforeUnmount(() => {
           />
         </template>
         <template #actions-header="{ column }">
-          <div
-            class="flex justify-center align-center flex-col h-full border-l-4 
-            border-solid border-gray-200 bg-white min-h-[120px]"
-          >
+          <!-- eslint-disable-next-line -->
+          <div class="flex justify-center align-center flex-col h-full border-l-4 border-solid border-gray-200 bg-white min-h-[120px]">
             <div class="px-2">
               {{ column.label }}
             </div>
@@ -281,22 +284,22 @@ onBeforeUnmount(() => {
             <span
               v-for="(file, i) in row.consumerFilenames"
               :key="`file-${i}`"
-              class="block my-1"
+              class="block my-2"
             >
               <DocumentsTableDownloadLink
                 :download-url="row.documentUrls[i]"
                 :file-name="file"
               />
             </span>
-            <span>
+            <span class="my-2">
               <ULink inactive-class="text-primary" class="flex align-center">
-                <UIcon name="i-mdi-download" class="w-5 h-5" />
+                <UIcon name="i-mdi-download mr-1.5" class="w-5 h-5" />
                 {{ $t("documentSearch.table.downloadAll") }}
               </ULink>
             </span>
           </div>
           <div v-else>
-            <span class="block my-1">
+            <span class="block my-2">
               <DocumentsTableDownloadLink
                 :download-url="row.documentUrls[0]"
                 :file-name="row.consumerFilenames[0]"
@@ -305,10 +308,7 @@ onBeforeUnmount(() => {
           </div>
         </template>
         <template #description-data="{ row }">
-          <div
-            v-if="row.description" 
-            class="w-[300px]"
-          >
+          <div v-if="row.description" class="w-[300px]">
             <p>
               {{
                 isDescriptionExpanded[row.consumerDocumentId]

--- a/document-service/documents-ui/src/components/documentsTable/index.vue
+++ b/document-service/documents-ui/src/components/documentsTable/index.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { formatToReadableDate } from "~/utils/dateHelper"
 import { documentResultColumns } from "~/utils/documentTypes"
+import { truncate } from "~/utils/documentRecords"
 import type { DocumentInfoIF } from "~/interfaces/document-types-interface"
 const {
   getDocumentDescription,
-  downloadFileFromUrl,
   searchDocumentRecords,
   getDocumentTypesByClass,
   getNextDocumentsPage,
@@ -16,14 +16,18 @@ const {
   documentSearchResults,
   searchDocumentId,
   searchEntityId,
+  searchEntityType,
   searchDocuments,
   searchDocumentType,
   searchDateRange,
+  searchDescription,
+  searchResultCount,
   isLoading,
 } = storeToRefs(useBcrosDocuments())
 
 const documentRecordsTableRef = ref(null)
-const documentRecordColumns = ref([])
+const columnsToShow = ref(documentResultColumns)
+const isDescriptionExpanded = ref({})
 
 const isFiltered = computed(() => {
   return (
@@ -56,11 +60,19 @@ const handleTableScroll = () => {
     }
   }
 }
+const toggleDescription = (consumerDocumentId) => {
+  isDescriptionExpanded.value[consumerDocumentId] =
+    !isDescriptionExpanded.value[consumerDocumentId]
+}
+
+const changeColumns = (selected: [string]) => {
+  columnsToShow.value = documentResultColumns.filter(
+    (column) => column.isFixed || selected.includes(column.key)
+  )
+}
 
 onMounted(() => {
-  documentRecordColumns.value = documentResultColumns()
   searchDocumentRecords()
-
   const tableElement = documentRecordsTableRef.value?.$el
   if (tableElement) {
     tableElement.addEventListener("scroll", handleTableScroll)
@@ -83,20 +95,45 @@ onBeforeUnmount(() => {
   >
     <template #header>
       <div class="flex justify-between items-center">
-        <span>{{ $t("documentSearch.table.title") }} (123)</span>
+        <span>
+          {{ $t("documentSearch.table.title") }}
+          ({{ searchResultCount || 0 }})
+        </span>
+        <div class="flex gap-4">
+          <span>
+            <USelectMenu
+              v-model="searchEntityType"
+              :placeholder="$t('documentSearch.form.selectMenu.categoryLabel')"
+              class="text-gray-700 text-light w-[300px]"
+              :options="documentTypes"
+              value-attribute="class"
+              option-attribute="description"
+              size="md"
+              :popper="{ placement: 'bottom-start' }"
+              :ui="{
+                icon: { trailing: { pointer: '' } },
+                size: { md: 'h-[44px]' },
+              }"
+              trailing-icon="i-mdi-arrow-drop-down"
+            />
+          </span>
+
+          <InputMultiSelector
+            :options="documentResultColumns.filter((column) => !column.isFixed)"
+            class="w-[250px]"
+            value-attribute="key"
+            option-attribute="label"
+            :label="$t('documentSearch.table.headers.columnsToShow')"
+            @change-columns="changeColumns"
+          />
+        </div>
       </div>
     </template>
     <template #content>
       <UTable
         ref="documentRecordsTableRef"
-        :columns="documentRecordColumns"
+        :columns="columnsToShow"
         :rows="documentSearchResults || []"
-        :sort-button="{
-          class: 'font-bold text-sm',
-          size: '2xs',
-          square: false,
-          ui: { rounded: 'rounded-full' },
-        }"
         :loading="isLoading"
         :empty-state="{
           icon: null,
@@ -144,7 +181,7 @@ onBeforeUnmount(() => {
               <USelectMenu
                 v-model="searchDocumentType"
                 :placeholder="column.label"
-                class="w-full px-2 font-light"
+                class="w-full px-2 font-light w-[250px]"
                 select-class="text-gray-700"
                 :options="getDocumentTypesByClass()"
                 value-attribute="type"
@@ -165,6 +202,7 @@ onBeforeUnmount(() => {
                     :padded="false"
                     @click="searchDocumentType = ''"
                   />
+                  <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5" />
                 </template>
               </USelectMenu>
             </div>
@@ -179,7 +217,7 @@ onBeforeUnmount(() => {
             <div class="h-11">
               <InputDatePicker
                 v-model="searchDateRange"
-                class="w-full px-2 font-light"
+                class="w-[265px] px-2 font-light"
                 is-ranged-picker
                 is-left-bar
                 is-filter
@@ -190,25 +228,30 @@ onBeforeUnmount(() => {
         </template>
         <template #description-header="{ column }">
           <DocumentsTableInputHeader
-            v-model="searchDocumentId"
+            v-model="searchDescription"
             :column="column"
           />
         </template>
         <template #actions-header="{ column }">
-          <div class="px-2">
-            {{ column.label }}
-          </div>
-          <UDivider class="my-3" />
-          <div>
-            <div class="flex justify-center h-11">
-              <UButton
-                v-if="isFiltered"
-                class="h-[44px] px-3 py-3 text-sm"
-                :label="$t('documentSearch.table.clearFilter')"
-                icon="i-mdi-cancel-circle"
-                variant="outline"
-                color="primary"
-              />
+          <div
+            class="flex justify-center align-center flex-col h-full border-l-4 
+            border-solid border-gray-200 bg-white min-h-[120px]"
+          >
+            <div class="px-2">
+              {{ column.label }}
+            </div>
+            <UDivider class="my-3" />
+            <div>
+              <div class="flex justify-center h-11">
+                <UButton
+                  v-if="isFiltered"
+                  class="h-[44px] px-3 py-3 text-sm"
+                  :label="$t('documentSearch.table.clearFilter')"
+                  icon="i-mdi-cancel-circle"
+                  variant="outline"
+                  color="primary"
+                />
+              </div>
             </div>
           </div>
         </template>
@@ -240,14 +283,10 @@ onBeforeUnmount(() => {
               :key="`file-${i}`"
               class="block my-1"
             >
-              <ULink
-                inactive-class="text-primary"
-                class="flex align-center"
-                @click="downloadFileFromUrl(row.documentUrls[i], file)"
-              >
-                <UIcon name="i-mdi-file-download" class="w-5 h-5" />
-                {{ file }}
-              </ULink>
+              <DocumentsTableDownloadLink
+                :download-url="row.documentUrls[i]"
+                :file-name="file"
+              />
             </span>
             <span>
               <ULink inactive-class="text-primary" class="flex align-center">
@@ -258,32 +297,52 @@ onBeforeUnmount(() => {
           </div>
           <div v-else>
             <span class="block my-1">
-              <ULink
-                inactive-class="text-primary"
-                class="flex align-center"
-                @click="
-                  downloadFileFromUrl(
-                    row.documentUrls[0],
-                    row.consumerFilenames[0]
-                  )
-                "
-              >
-                <UIcon name="i-mdi-file-download" class="w-5 h-5" />
-                {{ row.consumerFilenames[0] }}
-              </ULink>
+              <DocumentsTableDownloadLink
+                :download-url="row.documentUrls[0]"
+                :file-name="row.consumerFilenames[0]"
+              />
             </span>
+          </div>
+        </template>
+        <template #description-data="{ row }">
+          <div
+            v-if="row.description" 
+            class="w-[300px]"
+          >
+            <p>
+              {{
+                isDescriptionExpanded[row.consumerDocumentId]
+                  ? row.description
+                  : truncate(row.description, 150, 145)
+              }}
+            </p>
+            <ULink
+              v-if="row.description.length > 150"
+              class="text-primary"
+              @click="toggleDescription(row.consumerDocumentId)"
+            >
+              {{
+                isDescriptionExpanded[row.consumerDocumentId]
+                  ? "Read Less"
+                  : "Read More"
+              }}
+            </ULink>
           </div>
         </template>
         <!-- Actions -->
         <template #actions-data="{ row }">
-          <UButton
-            class="relative h-[35px] px-8 text-base"
-            outlined
-            color="primary"
-            @click="openDocumentRecord(row)"
+          <div
+            class="flex justify-center items-center h-full border-l-4 border-solid border-gray-200 bg-white"
           >
-            {{ $t("button.open") }}
-          </UButton>
+            <UButton
+              class="relative h-[35px] px-8 text-base"
+              outlined
+              color="primary"
+              @click="openDocumentRecord(row)"
+            >
+              {{ $t("button.open") }}
+            </UButton>
+          </div>
         </template>
       </UTable>
     </template>

--- a/document-service/documents-ui/src/components/documentsTable/inputHeader.vue
+++ b/document-service/documents-ui/src/components/documentsTable/inputHeader.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
-import type { TableColumnIF } from "~/interfaces/table-inferface"
+import { debounce } from 'lodash'
+import type { TableColumnIF } from '~/interfaces/table-interfaces'
 
-const props = defineProps({
-  modelValue: {
-    type: String,
-    default: "",
-  },
+defineProps({
   column: {
     type: Object as PropType<TableColumnIF>,
     default: () => {},
@@ -13,10 +10,14 @@ const props = defineProps({
 })
 
 const emit = defineEmits(["update:model-value"])
+const filterValue = ref('')
 
-const filerValue = computed({
-  get: () => props.modelValue,
-  set: (value) => emit("update:model-value", value),
+const debouncedInput = debounce((newValue) => {
+  emit('update:model-value', newValue);
+}, 500)
+
+watch(filterValue, (newValue) => {
+  debouncedInput(newValue)
 })
 </script>
 <template>
@@ -27,17 +28,18 @@ const filerValue = computed({
         v-if="column.tooltipText"
         :popper="{ placement: 'top', arrow: true }"
         :text="column.tooltipText"
+        :ui="{base: 'w-[265px]'}"
       >
         <UIcon
           name="i-mdi-information-outline"
-          class="font-bold w-5 h-5 mx-2"
+          class="font-bold w-5 h-5 mx-2 text-primary"
         />
       </UTooltip>
     </div>
     <UDivider class="my-3 w-full" />
     <div class="h-11">
       <UInput
-        v-model="filerValue"
+        v-model="filterValue"
         class="w-full px-2 font-light"
         size="md"
         :placeholder="column.label"
@@ -45,15 +47,16 @@ const filerValue = computed({
           icon: { trailing: { pointer: '' } },
           size: { md: 'h-[44px]' },
         }"
+ 
       >
         <template #trailing>
           <UButton
-            v-show="filerValue !== ''"
+            v-show="filterValue !== ''"
             color="gray"
             variant="link"
             icon="i-mdi-cancel-circle text-primary"
             :padded="false"
-            @click="filerValue = ''"
+            @click="filterValue = ''"
           />
         </template>
       </UInput>

--- a/document-service/documents-ui/src/composables/useDocuments.ts
+++ b/document-service/documents-ui/src/composables/useDocuments.ts
@@ -263,7 +263,7 @@ export const useDocuments = () => {
 
   /** Get next page of document records if exists */
   const getNextDocumentsPage = () => {
-    if(hasMorePages) {
+    if(hasMorePages.value) {
       pageNumber.value += 1
       searchDocumentRecords()
     }

--- a/document-service/documents-ui/src/composables/useDocuments.ts
+++ b/document-service/documents-ui/src/composables/useDocuments.ts
@@ -184,8 +184,6 @@ export const useDocuments = () => {
     return Math.ceil(searchResultCount.value / pageSize) > pageNumber.value
   })
 
-  const debouncedSearch = debounce(searchDocumentRecords)
-
   /** Validate and Save Document Indexing */
   const saveDocuments = async (): Promise<void> => {
     // Validate Document Indexing
@@ -278,6 +276,7 @@ export const useDocuments = () => {
     if (id.length >= 1) findCategoryByPrefix(id, true)
   })
 
+  
   return {
     isValidIndexData,
     findCategoryByPrefix,
@@ -287,7 +286,6 @@ export const useDocuments = () => {
     downloadFileFromUrl,
     hasMinimumSearchCriteria,
     saveDocuments,
-    debouncedSearch,
     scrollToFirstError,
     getNextDocumentsPage
   }

--- a/document-service/documents-ui/src/interfaces/document-types-interface.ts
+++ b/document-service/documents-ui/src/interfaces/document-types-interface.ts
@@ -5,6 +5,7 @@ export interface DocumentStateIF {
   searchResultCount: number
   searchDocumentId: string
   searchEntityId: string
+  searchEntityType: string
   searchDocuments: string
   searchDocumentClass: string
   searchDocumentType: string
@@ -12,20 +13,24 @@ export interface DocumentStateIF {
     start: Date | null
     end: Date | null
   }
+  searchDescription: string
   pageNumber: number
 
   // Document Meta
+  consumerDocumentId: string
   consumerIdentifier: string
   noIdCheckbox: boolean
   noDocIdCheckbox: boolean
   documentClass: string
   documentType: string
+  description: string
   consumerFilingDate: string
   documentList: Array<any>
 
   // Validations
   validateIndex: boolean
   isLoading: boolean
+  validateDocumentSearch: boolean
 
   // Document Review
   displayDocumentReview: boolean

--- a/document-service/documents-ui/src/interfaces/request-interfaces.ts
+++ b/document-service/documents-ui/src/interfaces/request-interfaces.ts
@@ -21,6 +21,7 @@ export interface DocumentRequestIF {
   consumerDocumentId?: string
   documentClass: string
   documentType: string
+  description?: string
   consumerIdentifier?: string
   consumerFilingDate?: string
   consumerFilename?: string

--- a/document-service/documents-ui/src/interfaces/table-interfaces.ts
+++ b/document-service/documents-ui/src/interfaces/table-interfaces.ts
@@ -1,0 +1,8 @@
+// Define a type for the Table Column
+export interface TableColumnIF {
+  key: string
+  label: string
+  tooltipText?: string
+  sortable?: boolean
+  isFixed?: boolean
+}

--- a/document-service/documents-ui/src/lang/en.json
+++ b/document-service/documents-ui/src/lang/en.json
@@ -55,6 +55,7 @@
         "documentType": "Document Type",
         "documentDescription": "Document Description",
         "actions": "Actions",
+        "entityType": "Select Entity Type",
         "columnsToShow": "Columns to Show"
       },
       "downloadAll": "Download All",

--- a/document-service/documents-ui/src/lang/en.json
+++ b/document-service/documents-ui/src/lang/en.json
@@ -54,7 +54,8 @@
         "filingDate": "Filing Date",
         "documentType": "Document Type",
         "documentDescription": "Document Description",
-        "actions": "Actions"
+        "actions": "Actions",
+        "columnsToShow": "Columns to Show"
       },
       "downloadAll": "Download All",
       "noResult": "No results found.",

--- a/document-service/documents-ui/src/pages/DocumentManagement.vue
+++ b/document-service/documents-ui/src/pages/DocumentManagement.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { documentRecordHelpContent } from '~/utils/documentTypes';
+// import { documentRecordHelpContent } from '~/utils/documentTypes';
 const { resetStore } = useBcrosDocuments()
-const { documentSearchResults } = storeToRefs(useBcrosDocuments())
+// const { documentSearchResults } = storeToRefs(useBcrosDocuments())
 
-const isHelpContentOpen = ref(false)
-const hasBottomHideToggle = ref(true)
+// const isHelpContentOpen = ref(false)
+// const hasBottomHideToggle = ref(true)
 
-const toggleHelpContent = () => {
-  isHelpContentOpen.value = !isHelpContentOpen.value
-}
+// const toggleHelpContent = () => {
+//   isHelpContentOpen.value = !isHelpContentOpen.value
+// }
 const launchCreateRecord = () => {
   resetStore()
   navigateTo({ name: RouteNameE.DOCUMENT_INDEXING })
@@ -30,7 +30,7 @@ const launchCreateRecord = () => {
           </div>
           <!-- Hiding help button until we get the content -->
           <!-- Help content -->
-          <HelpToggleContainer
+          <!-- <HelpToggleContainer
             :is-help-content-open="isHelpContentOpen"
             :has-bottom-hide-toggle="hasBottomHideToggle"
             @toggle-help-content="toggleHelpContent"
@@ -40,7 +40,7 @@ const launchCreateRecord = () => {
                 {{ documentRecordHelpContent }}
               </p>
             </template>
-          </HelpToggleContainer>
+          </HelpToggleContainer> -->
           <div>
             <UButton
               class="mt-5 py-2 px-6 text-base font-bold rounded"
@@ -60,7 +60,6 @@ const launchCreateRecord = () => {
     </BcrosSection>
   
     <!-- Document Search Results -->
-    <UDivider v-if="documentSearchResults.length" class="pt-[60px] pb-4" />
     <DocumentsTable />
   </div>
 </template>

--- a/document-service/documents-ui/src/pages/DocumentManagement.vue
+++ b/document-service/documents-ui/src/pages/DocumentManagement.vue
@@ -43,7 +43,7 @@ const launchCreateRecord = () => {
           </HelpToggleContainer>
           <div>
             <UButton
-              class="mt-5 py-2 px-6 text-base font-bold"
+              class="mt-5 py-2 px-6 text-base font-bold rounded"
               outlined
               color="primary"
               @click="launchCreateRecord()"

--- a/document-service/documents-ui/src/stores/documents.ts
+++ b/document-service/documents-ui/src/stores/documents.ts
@@ -8,11 +8,12 @@ export const useBcrosDocuments = defineStore('bcros/documents', () => {
     searchResultCount: 0,
     searchDocumentId: '',
     searchDocuments: '',
-    // Pre-populated these values for review purpose.
     searchEntityId: '',
+    searchEntityType: '',
     searchDocumentClass: '',
     searchDocumentType: '',
     searchDateRange: { start: null, end: null },
+    searchDescription: '',
     pageNumber: 1,
 
     // Document Meta

--- a/document-service/documents-ui/src/utils/documentRecords.ts
+++ b/document-service/documents-ui/src/utils/documentRecords.ts
@@ -2,19 +2,28 @@
 export const pageSize = 100
 
 /**
- * Returns a debounced version of a function, delaying its execution until after a timeout.
- * 
- * @param func - The function to debounce.
- * @param timeout - The number of milliseconds to delay execution (default is 200).
- * @returns A debounced version of the provided function.
+ * Truncates a string either by the end or the middle based on the presence of `backChars`.
+ * If `backChars` is not specified, it truncates the string from the end and adds '...'.
+ * If `backChars` is specified, it truncates from the middle, keeping a specified number 
+ * of characters from both the front and back, with '...' in the middle.
+ *
+ * @param {string} str - The original string to be truncated.
+ * @param {number} maxLength - The maximum length of the truncated string, including '...'.
+ * @param {number} frontChars - The number of characters to keep at the beginning of the string.
+ * @param {number} [backChars] - Optional. The number of characters to keep at the end of the string. 
+ *                              If not provided, truncates from the end.
+ * @returns {string} - The truncated string with either '...' at the end or in the middle.
  */
-export function debounce(func, timeout = 200) {
-  let timeoutId;
-  return (...args) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => {
-      func(...args);
-    }, timeout);
-  };
-}
+export function truncate(str: string, maxLength: number, frontChars: number, backChars: number = undefined) {
+  if (str.length <= maxLength) return str;
 
+  if (typeof backChars === 'undefined') {
+    // End truncation if backChars is not specified
+    return str.slice(0, frontChars) + '...';
+  }
+
+  // Middle truncation if backChars is specified
+  const front = str.slice(0, frontChars);
+  const back = str.slice(-backChars);
+  return `${front}...${back}`;
+}

--- a/document-service/documents-ui/src/utils/documentTypes.ts
+++ b/document-service/documents-ui/src/utils/documentTypes.ts
@@ -1,3 +1,5 @@
+import type { DocumentClassIF } from '~/interfaces/document-types-interface'
+
 /**
  * @file documentTypes.ts
  * @description Exports an object categorizing document types by entity type. Each category includes:
@@ -5,7 +7,7 @@
  * - `prefixes`: Array of document prefixes.
  * - `documents`: Array of document details (type, description, product code).
  */
-export const documentTypes = [
+export const documentTypes: Array<DocumentClassIF> = [
   {
     class: 'COOP',
     description: 'Cooperatives',
@@ -47,6 +49,65 @@ export const documentTypes = [
       { type: 'FIRM_MISC', description: 'Firms miscellaneous documents', productCode: 'business' },
       { type: 'CNVF', description: 'Conversion of Firm', productCode: 'business' },
       { type: 'COPN', description: 'Change of Proprietor\'s Name', productCode: 'business' }
+    ]
+  },
+  
+  {
+    class: 'SOCIETY',
+    description: 'Societies',
+    prefixes: ['S', 'XS', 'S-', 'XS-', 'S/', 'XS/'],
+    documents: [
+      { type: 'SOC_MISC', description: 'Societies miscellaneous documents', productCode: 'business' },
+      { type: 'SOCF', description: 'Society Filing', productCode: 'business' },
+      { type: 'CORC', description: 'Corrections', productCode: 'business' },
+      { type: 'ADDR', description: 'Address', productCode: 'business' },
+      { type: 'ANNR', description: 'Annual Report', productCode: 'business' },
+      { type: 'CORR', description: 'Correspondence', productCode: 'business' },
+      { type: 'DIRS', description: 'Directors', productCode: 'business' }
+    ]
+  },
+  {
+    class: 'OTHER',
+    description: 'Other',
+    prefixes: [],
+    documents: [
+      { type: 'CERT', description: 'Certificates', productCode: 'business' },
+      { type: 'LTR', description: 'Letter Templates', productCode: 'business' },
+      { type: 'CLW', description: 'Client Letters', productCode: 'business' },
+      { type: 'BYLW', description: 'Bylaw', productCode: 'business' },
+      { type: 'CNST', description: 'Constitution', productCode: 'business' },
+      { type: 'CONT', description: 'Consent', productCode: 'business' },
+      { type: 'SYSR', description: 'System is the record', productCode: 'business' },
+      { type: 'ADMN', description: 'Administration', productCode: 'business' },
+      { type: 'RSLN', description: 'Resolution Document', productCode: 'business' },
+      { type: 'AFDV', description: 'Affidavit Document', productCode: 'business' },
+      { type: 'SUPP', description: 'Supporting Documents', productCode: 'business' },
+      { type: 'MNOR', description: 'Minister\'s Order', productCode: 'business' },
+      { type: 'FINM', description: 'Financial Management', productCode: 'business' },
+      { type: 'APCO', description: 'Application to Correct the Registry', productCode: 'business' },
+      { type: 'RPTP', description: 'Report of Payments', productCode: 'business' },
+      { type: 'DAT', description: 'DAT or CAT', productCode: 'business' },
+      { type: 'BYLT', description: 'Bylaw Alterations', productCode: 'business' },
+      { type: 'CNVS', description: 'Conversions', productCode: 'business' },
+      { type: 'CRTO', description: 'Court Orders', productCode: 'business' },
+      { type: 'MEM', description: 'Membership', productCode: 'business' },
+      { type: 'PRE', description: 'Pre Image Documents', productCode: 'business' },
+      { type: 'REGO', description: 'Registrar\'s Order', productCode: 'business' },
+      { type: 'PLNA', description: 'Plan of Arrangements', productCode: 'business' },
+      { type: 'REGN', description: 'Registrar\'s Notation', productCode: 'business' },
+      { type: 'FINC', description: 'Financial', productCode: 'business' },
+      { type: 'BCGT', description: 'BC Gazette', productCode: 'business' },
+      { type: 'CHNM', description: 'Change Of Name', productCode: 'business' },
+      { type: 'OTP', description: 'OTP', productCode: 'business' }
+    ]
+  },
+  {
+    class: 'NR',
+    description: 'Name Requests',
+    prefixes: ['NR'],
+    documents: [
+      { type: 'NR_MISC', description: 'Name requests miscellaneous documents', productCode: 'nro' },
+      { type: 'CONS', description: 'NR Consent Letter', productCode: 'nro' }
     ]
   },
   {
@@ -106,15 +167,6 @@ export const documentTypes = [
     ]
   },
   {
-    class: 'NR',
-    description: 'Name Requests',
-    prefixes: ['NR'],
-    documents: [
-      { type: 'NR_MISC', description: 'Name requests miscellaneous documents', productCode: 'nro' },
-      { type: 'CONS', description: 'NR Consent Letter', productCode: 'nro' }
-    ]
-  },
-  {
     class: 'PPR',
     description: 'Personal Property Registry',
     prefixes: ['PPR'],
@@ -124,55 +176,6 @@ export const documentTypes = [
       { type: 'PPRC', description: 'PPR Secure Party Codes', productCode: 'ppr' }
     ]
   },
-  {
-    class: 'SOCIETY',
-    description: 'Societies',
-    prefixes: ['S', 'XS', 'S-', 'XS-', 'S/', 'XS/'],
-    documents: [
-      { type: 'SOC_MISC', description: 'Societies miscellaneous documents', productCode: 'business' },
-      { type: 'SOCF', description: 'Society Filing', productCode: 'business' },
-      { type: 'CORC', description: 'Corrections', productCode: 'business' },
-      { type: 'ADDR', description: 'Address', productCode: 'business' },
-      { type: 'ANNR', description: 'Annual Report', productCode: 'business' },
-      { type: 'CORR', description: 'Correspondence', productCode: 'business' },
-      { type: 'DIRS', description: 'Directors', productCode: 'business' }
-    ]
-  },
-  {
-    class: 'OTHER',
-    description: 'Other',
-    prefixes: [],
-    documents: [
-      { type: 'CERT', description: 'Certificates', productCode: 'business' },
-      { type: 'LTR', description: 'Letter Templates', productCode: 'business' },
-      { type: 'CLW', description: 'Client Letters', productCode: 'business' },
-      { type: 'BYLW', description: 'Bylaw', productCode: 'business' },
-      { type: 'CNST', description: 'Constitution', productCode: 'business' },
-      { type: 'CONT', description: 'Consent', productCode: 'business' },
-      { type: 'SYSR', description: 'System is the record', productCode: 'business' },
-      { type: 'ADMN', description: 'Administration', productCode: 'business' },
-      { type: 'RSLN', description: 'Resolution Document', productCode: 'business' },
-      { type: 'AFDV', description: 'Affidavit Document', productCode: 'business' },
-      { type: 'SUPP', description: 'Supporting Documents', productCode: 'business' },
-      { type: 'MNOR', description: 'Minister\'s Order', productCode: 'business' },
-      { type: 'FINM', description: 'Financial Management', productCode: 'business' },
-      { type: 'APCO', description: 'Application to Correct the Registry', productCode: 'business' },
-      { type: 'RPTP', description: 'Report of Payments', productCode: 'business' },
-      { type: 'DAT', description: 'DAT or CAT', productCode: 'business' },
-      { type: 'BYLT', description: 'Bylaw Alterations', productCode: 'business' },
-      { type: 'CNVS', description: 'Conversions', productCode: 'business' },
-      { type: 'CRTO', description: 'Court Orders', productCode: 'business' },
-      { type: 'MEM', description: 'Membership', productCode: 'business' },
-      { type: 'PRE', description: 'Pre Image Documents', productCode: 'business' },
-      { type: 'REGO', description: 'Registrar\'s Order', productCode: 'business' },
-      { type: 'PLNA', description: 'Plan of Arrangements', productCode: 'business' },
-      { type: 'REGN', description: 'Registrar\'s Notation', productCode: 'business' },
-      { type: 'FINC', description: 'Financial', productCode: 'business' },
-      { type: 'BCGT', description: 'BC Gazette', productCode: 'business' },
-      { type: 'CHNM', description: 'Change Of Name', productCode: 'business' },
-      { type: 'OTP', description: 'OTP', productCode: 'business' }
-    ]
-  }
 ]
 
 export const documentResultColumns: Array<TableColumnIF> = [

--- a/document-service/documents-ui/src/utils/documentTypes.ts
+++ b/document-service/documents-ui/src/utils/documentTypes.ts
@@ -1,5 +1,3 @@
-import type { DocumentClassIF } from '~/interfaces/document-types-interface'
-
 /**
  * @file documentTypes.ts
  * @description Exports an object categorizing document types by entity type. Each category includes:
@@ -7,7 +5,7 @@ import type { DocumentClassIF } from '~/interfaces/document-types-interface'
  * - `prefixes`: Array of document prefixes.
  * - `documents`: Array of document details (type, description, product code).
  */
-export const documentTypes: Array<DocumentClassIF> = [
+export const documentTypes = [
   {
     class: 'COOP',
     description: 'Cooperatives',
@@ -177,52 +175,47 @@ export const documentTypes: Array<DocumentClassIF> = [
   }
 ]
 
-export const documentResultColumns = () => {
-  const t = useNuxtApp().$i18n.t  
-
-  return [
+export const documentResultColumns: Array<TableColumnIF> = [
     {
       key: 'emptyColumn',
-      label: t('documentSearch.table.headers.sortBy'),
-      sortable: false
+      label: 'Sort By',
+      isFixed: true
     },
     {
       key: 'consumerDocumentId',
-      label: t('documentSearch.table.headers.documentID'),
+      label: 'Document ID',
       tooltipText: `The Document ID, also known as the Barcode Number, 
                 is a unique identifier assigned to a document record.`,
       sortable: true
     },
     {
       key: 'consumerIdentifier',
-      label: t('documentSearch.table.headers.entityID'),
+      label: 'Entity ID',
       tooltipText: 'Maecenas sed diam eget risus varius blandit sit amet non magna.',
       sortable: true
     },
     {
       key: 'documentURL',
-      label: t('documentSearch.table.headers.documents')
+      label: 'Documents'
     },
     {
       key: 'documentTypeDescription',
-      label: t('documentSearch.table.headers.documentType')
+      label: 'Document Type'
     },
     {
       key: 'consumerFilingDateTime',
-      label: t('documentSearch.table.headers.filingDate')
+      label: 'Filing Date'
     },
     {
       key: 'description',
-      label: t('documentSearch.table.headers.documentDescription')
+      label: 'Document Description'
     },
     {
       key: 'actions',
-      label: t('documentSearch.table.headers.actions'),
-      class: 'sticky right-0'
+      label: 'Actions',
+      isFixed: true
     }
   ]
-  
-}
 
 export const documentRecordHelpContent = `
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. 

--- a/document-service/documents-ui/tests/unit/DocumentsTable.spec.ts
+++ b/document-service/documents-ui/tests/unit/DocumentsTable.spec.ts
@@ -61,7 +61,9 @@ describe('DocumentsTable', () => {
     // Verify the first row's content
     const firstRowCells = rows[0].findAll('td')
     expect(firstRowCells[1].text()).toBe(mockDocumentResults[0].consumerDocumentId)
-    expect(firstRowCells[2].text()).toBe(mockDocumentResults[0].consumerIdentifier)
+    expect(firstRowCells[2].text()).toBe(
+      mockDocumentResults[0].consumerIdentifier + mockDocumentResults[0].documentTypeDescription
+    )
     expect(firstRowCells[4].text()).toBe(mockDocumentResults[0].documentTypeDescription)
     expect(firstRowCells[5].text()).toContain(formatToReadableDate('2024-08-03T19:00:00+00:00', true))
 


### PR DESCRIPTION
#22806

- [x] Document Record results showing incorrect results
- [x] Padding should be 20px above the sort by column
- [x] Missing drop-downs in header: Entity Type and Columns to Show
- [x] Breaklines should span the whole width of the table
- [x] Sort and Filter By text should be 14px #495057
- [x] field heigh should be 44px 
- [x] missing dropdown button in Document Type field
- [x] Missing icon in Date Range Picker 
- [x] Missing 'Description' column (see Sort By / Filter By Styling in figma File)
- [x] Corder Radius's in fields should be 4px 
- [x] Date range picker is showing single date selector. (See Sort By / Filter By Styling and Varients - Date Range Picker) *Again this may be for ticket #23120
- [x] Tool Tip width should be 265px
- [x] Icon colour should be #1669BB
- [x] Buttons | Corder Radius's should be 4px 


![image](https://github.com/user-attachments/assets/4c66b20f-0358-4cb6-bcb7-a5a5108da38f)

