### PR TITLE
Document Info page & updated styles on edit document

### DIFF
--- a/document-service/documents-ui/src/app.config.ts
+++ b/document-service/documents-ui/src/app.config.ts
@@ -91,6 +91,9 @@ export default defineAppConfig({
         background: 'bg-gray-900/75',
       }
     },
+    badge: {
+      font: 'font-bold'
+    },
     button: {
       rounded: 'rounded'
     },

--- a/document-service/documents-ui/src/components/documentIndexingForm/index.vue
+++ b/document-service/documents-ui/src/components/documentIndexingForm/index.vue
@@ -161,6 +161,11 @@ watch(() => documentClass.value, () => {
                 <template #trailing>
                   <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5 " />
                 </template>
+                <template #option="{ option, selected }">
+                  <span :class="selected ? '' : 'text-gray-700'">
+                    {{ option.description }}
+                  </span>
+                </template>
               </USelectMenu>
               </UFormGroup>
             </div>

--- a/document-service/documents-ui/src/components/documentRecord/EditRecord.vue
+++ b/document-service/documents-ui/src/components/documentRecord/EditRecord.vue
@@ -168,7 +168,16 @@ documentRecord.documentClass
                         value-attribute="type"
                         option-attribute="description"
                         :ui="{ placeholder: hasTypeError ? 'placeholder:text-red-500' : 'text-gray-700' }"
-                      />
+                      >
+                      <template #trailing>
+                        <UIcon name="i-mdi-arrow-drop-down" class="w-5 h-5 " />
+                      </template>
+                      <template #option="{ option, selected }">
+                        <span :class="selected ? '' : 'text-gray-700'" >
+                          {{ option.description }}
+                        </span>
+                      </template>
+                      </USelectMenu>
                     </UFormGroup>
                   </div>
                 </div>

--- a/document-service/documents-ui/src/components/documentRecord/index.vue
+++ b/document-service/documents-ui/src/components/documentRecord/index.vue
@@ -104,9 +104,10 @@ const { fetchUrlAndDownload, getDocumentDescription } = useDocuments()
         <span class="col-span-2">
           {{ formatToReadableDate(documentRecord.consumerFilingDateTime, true) || 'Not Entered' }}
         </span>
-        <!-- Hiding `Author` due to UX/UI requirement -->
-        <!-- <span class="font-bold">{{ $t('documentReview.labels.author') }}</span>
-        <span class="col-span-2">{{ scanningDetails?.author }}</span> -->
+        <template v-if="documentRecord.consumerDocumentId.length === 8">
+          <span class="font-bold">{{ $t('documentReview.labels.author') }}</span>
+          <span class="col-span-2">{{ scanningDetails?.author }}</span>
+        </template>
 
         <!-- Scanning Information -->
         <UDivider class="my-6 col-span-3" />
@@ -119,7 +120,15 @@ const { fetchUrlAndDownload, getDocumentDescription } = useDocuments()
             :current-state="scanningDetails"
           />
         </span>
-        <span class="col-span-2"/>
+        <span class="col-span-2">
+          <UBadge
+            v-if="documentRecord.consumerDocumentId.length === 8"
+            variant="solid"
+            color="primary"
+            label="SCANNING PENDDING"
+            class="badge px-2.5 py-1.5"
+          />
+        </span>
 
         <span class="font-bold">{{ $t('documentReview.labels.accessionNumber') }}</span>
         <span class="col-span-2">{{ scanningDetails?.accessionNumber }}</span>
@@ -170,7 +179,7 @@ const { fetchUrlAndDownload, getDocumentDescription } = useDocuments()
   </ContentWrapper>
 </template>
 <style scoped lang="scss">
-span:not(.spanLink, #updated-badge-component) {
+span:not(.spanLink, .badge, #updated-badge-component) {
   padding: 0.5rem 0;
 }
 </style>

--- a/document-service/documents-ui/src/components/entityTypeSelector/index.vue
+++ b/document-service/documents-ui/src/components/entityTypeSelector/index.vue
@@ -76,11 +76,14 @@ watch(documentClass, (newValue) => {
       },
     }"
   >
-    <template #option="{ option }">
+    <template #option="{ option, selected }">
       <UDivider v-if="option.class === 'BreakLine'" />
-      <span v-else class="truncate px-3 py-2 h-[44px] flex items-center">{{
-        option.description
-      }}</span>
+      <span 
+        v-else 
+        :class="['truncate px-3 py-2 h-[44px] flex items-center', selected ? '' : 'text-gray-700']"
+      >
+        {{ option.description }}
+      </span>
     </template>
     <template #trailing>
       <UButton

--- a/document-service/documents-ui/src/composables/useDocuments.ts
+++ b/document-service/documents-ui/src/composables/useDocuments.ts
@@ -314,7 +314,10 @@ export const useDocuments = () => {
   const retrieveDocumentRecord = async (identifier: string) => {
     try {
       // Fetch Document Record
-      const { data } = await getDocumentRecord(identifier)
+      const { data, status } = await getDocumentRecord(identifier) 
+      if(status.value === 'error') {
+        navigateTo({ name: RouteNameE.DOCUMENT_MANAGEMENT })
+      }
       if (data.value) {
         documentRecord.value = {
           ...data.value[0],


### PR DESCRIPTION
#23737
(Small changes are included from #23412)

- [x] Redirect to `document-management` page if document ID is not found
- [x] Author
- [x] Scan badge

- [x] Changed colors on document class and document type dropdowns. 

<img width="1567" alt="image" src="https://github.com/user-attachments/assets/4c1d7cdc-ebe5-48a8-885c-72563723f06a">


<img width="1962" alt="image" src="https://github.com/user-attachments/assets/44173106-2e57-4fdd-a698-60bc868803da">
