### PR TITLE
24235 - Fix for fee calculation on line items on NSF invoice

### DIFF
--- a/report-api/report-templates/non_sufficient_funds.html
+++ b/report-api/report-templates/non_sufficient_funds.html
@@ -462,10 +462,10 @@
 
                                 {{ month_names[month] }} {{ day|int }}, {{ year }}
                             </td>
-                            <td>${{"{:,.2f}".format(lineItemProduct.total - lineItemProduct.service_fees - lineItemProduct.gst)}}</td>
+                            <td>${{"{:,.2f}".format(lineItemProduct.total)}}</td>
                             <td>${{"{:,.2f}".format(lineItemProduct.gst)}}</td>
                             <td>${{"{:,.2f}".format(lineItemProduct.service_fees)}}</td>
-                            <td>${{"{:,.2f}".format(lineItemProduct.total)}}</td>
+                            <td>${{"{:,.2f}".format(lineItemProduct.total + lineItemProduct.gst + lineItemProduct.service_fees )}}</td>
                         </tr>
                     {% endfor %}
                 {% endfor %}


### PR DESCRIPTION
Currently the Fee column was calculated as `Total - Service Fee`. Now it has been changed so the Total column is calculated as `Fee + Service Fee`.