### PR TITLE
Checking for invoice's payment_date in statement template

### DIFF
--- a/report-api/report-templates/statement_transactions.html
+++ b/report-api/report-templates/statement_transactions.html
@@ -37,7 +37,12 @@
             {% endif %}
             
             {% if payment_method == 'EFT' %}
-                {% if invoice.payment_date | format_datetime('unix') <= statement.to_date | format_datetime('unix') %}
+                {% if 
+                    invoice.payment_date
+                    and statement.to_date
+                    and (invoice.payment_date | format_datetime('unix')
+                    <= statement.to_date | format_datetime('unix'))
+                %}
                     {% set totals.due = totals.due - invoice.paid %}
                 {% endif %}
 


### PR DESCRIPTION
Fixed an issue with the statement template not generating when the invoice's payment_date is not present.