### PR TITLE
Record Request Fix, Scan Badge and Duplicate Doc ID Handling

### DIFF
--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcros-documents-ui",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/document-service/documents-ui/src/components/documentRecord/index.vue
+++ b/document-service/documents-ui/src/components/documentRecord/index.vue
@@ -15,6 +15,8 @@ const {
   scanningDetailsSnapshot
 } = storeToRefs(useBcrosDocuments())
 const { updatedDocumentList, fetchUrlAndDownload, getDocumentDescription } = useDocuments()
+const isScanPending = computed(() => documentRecord.value.consumerDocumentId.length === 8 &&
+  !scanningDetails.value?.scanDateTime && documentRecord.value?.consumerFilenames?.length === 0)
 </script>
 <template>
   <ContentWrapper
@@ -121,10 +123,10 @@ const { updatedDocumentList, fetchUrlAndDownload, getDocumentDescription } = use
         </span>
         <span class="col-span-2">
           <UBadge
-            v-if="documentRecord.consumerDocumentId.length === 8"
+            v-if="isScanPending"
             variant="solid"
             color="primary"
-            label="SCAN PENDDING"
+            label="SCAN PENDING"
             class="badge px-2.5 py-1.5"
           />
         </span>
@@ -165,10 +167,10 @@ const { updatedDocumentList, fetchUrlAndDownload, getDocumentDescription } = use
                inactive-class="text-primary underline"
                :disabled="isReviewMode"
                @click="fetchUrlAndDownload(
-                  documentRecordSnapshot.documentClass, 
+                  documentRecordSnapshot.documentClass,
                   documentRecordSnapshot.documentServiceIds[i]
                 )"
-              > 
+              >
                {{ file.name }}
              </ULink>
           </span>

--- a/document-service/documents-ui/src/components/documentsTable/inputHeader.vue
+++ b/document-service/documents-ui/src/components/documentsTable/inputHeader.vue
@@ -25,7 +25,7 @@ watch(() => props.modelValue, (newValue) => {
   if (filterValue.value !== newValue) {
     filterValue.value = newValue
   }
-})
+}, { immediate: true })
 
 watch(filterValue, (newValue) => {
   debouncedInput(newValue)
@@ -37,7 +37,7 @@ watch(filterValue, (newValue) => {
     <UDivider class="my-3 w-full" />
     <div class="h-11">
       <UInput
-        v-if="column.key!=='description'" 
+        v-if="column.key!=='description'"
         v-model="filterValue"
         class="min-w-[190px] w-full px-2 font-light"
         size="md"
@@ -46,7 +46,7 @@ watch(filterValue, (newValue) => {
           icon: { trailing: { pointer: '' , wrapper: 'pr-3.5'} },
           size: { md: 'h-[44px]' },
         }"
- 
+
       >
         <template #trailing>
           <UButton

--- a/document-service/documents-ui/src/pages/DocumentRecords.vue
+++ b/document-service/documents-ui/src/pages/DocumentRecords.vue
@@ -10,6 +10,7 @@ const {
   isEditingReview,
   validateRecordEdit,
   isError,
+  searchDocumentId
 } = storeToRefs(useBcrosDocuments())
 
 /**
@@ -25,6 +26,7 @@ onMounted(async () => {
   try {
     await retrieveDocumentRecord(identifier)
     isLoading.value = false
+    searchDocumentId.value = identifier
   } catch (error) {
     console.error('Error fetching document record', error)
     navigateTo({ name: RouteNameE.DOCUMENT_MANAGEMENT })

--- a/document-service/documents-ui/src/utils/documentRequests.ts
+++ b/document-service/documents-ui/src/utils/documentRequests.ts
@@ -125,7 +125,7 @@ export async function postDocument(params: DocumentRequestIF, document: RequestD
  * @param document - The document data to be sent in the request body.
  * @returns A promise that resolves to either an ApiResponseIF on success or an ApiErrorIF on failure.
  */
-export async function updateDocument(params: DocumentRequestIF, document: RequestDataIF)
+export async function putDocument(params: DocumentRequestIF, document: RequestDataIF)
   : Promise<ApiResponseOrError> {
   const options = {
     method: 'PUT',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#25285 /bcgov/entity#26432 /bcgov/entity#25497 /bcgov/entity#25924

*Description of changes:*
- Fixes Document Upload request to PATCH when there is a record created with no files or POST when we want to add Documents to an existing record
- Handle Duplicate document records on Record Management 
- Preserve document id filter after opening or editing a document record
- Update Scan Pending badge to only display when 8 digits, no documents and there is no Scan Date. 
