### PR TITLE
DRS UI: Filter and Author QA

### DIFF
--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcros-documents-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/document-service/documents-ui/src/components/documentRecord/index.vue
+++ b/document-service/documents-ui/src/components/documentRecord/index.vue
@@ -107,7 +107,7 @@ const isScanPending = computed(() => documentRecord.value.consumerDocumentId.len
         </span>
         <template v-if="documentRecord.consumerDocumentId.length === 8">
           <span class="font-bold">{{ $t('documentReview.labels.author') }}</span>
-          <span class="col-span-2">{{ scanningDetails?.author }}</span>
+          <span class="col-span-2">{{ documentRecord?.author }}</span>
         </template>
 
         <!-- Scanning Information -->

--- a/document-service/documents-ui/src/components/documentsTable/index.vue
+++ b/document-service/documents-ui/src/components/documentsTable/index.vue
@@ -120,7 +120,7 @@ watch(() => [
     ) { return }
     pageNumber.value = 1
     searchDocumentRecords()
-})
+}, { immediate: true })
 
 watch(() => searchEntityId.value, (id: string) => {
     // Format Entity Identifier


### PR DESCRIPTION
- Fetch Author Data from Document Record (Not Scanning) 
- Update Table Filter Watcher to re fetch records that are not present in page 1 of the records 