### PR TITLE
Improved getDocumentRecord Handling

### DIFF
--- a/document-service/documents-ui/src/components/documentRecord/index.vue
+++ b/document-service/documents-ui/src/components/documentRecord/index.vue
@@ -106,7 +106,7 @@ const isScanPending = computed(() => documentRecord.value.consumerDocumentId.len
           {{ formatToReadableDate(documentRecord.consumerFilingDateTime, true) || 'Not Entered' }}
         </span>
         <span class="font-bold">{{ $t('documentReview.labels.author') }}</span>
-        <span class="col-span-2">{{ documentRecord?.author }}</span>
+        <span class="col-span-2">{{ documentRecord?.author || scanningDetails?.author || 'N/A' }}</span>
 
         <!-- Scanning Information -->
         <UDivider class="my-6 col-span-3" />

--- a/document-service/documents-ui/src/composables/useDocuments.ts
+++ b/document-service/documents-ui/src/composables/useDocuments.ts
@@ -405,13 +405,14 @@ export const useDocuments = () => {
       if(status.value === 'error') {
         navigateTo({ name: RouteNameE.DOCUMENT_MANAGEMENT })
       }
-      if (data.value) {
+      const docRecord = docClass ? data.value : data.value.results
+      if (docRecord) {
         const consumerFilenames = []
-        data.value.forEach(record => (record.consumerFilename && consumerFilenames.push(record.consumerFilename)))
+        docRecord.forEach(record => (record.consumerFilename && consumerFilenames.push(record.consumerFilename)))
         documentRecord.value = {
-          ...data.value.find(record => !!record.consumerFilename) || data.value[0],
+          ...docRecord.find(record => !!record.consumerFilename) || docRecord[0],
           consumerFilenames: consumerFilenames,
-          documentServiceIds: data.value.filter(record => record.consumerFilename)
+          documentServiceIds: docRecord.filter(record => record.consumerFilename)
             .map((record) => (record.documentServiceId))
         }
         documentList.value = documentRecord.value.consumerFilenames?.map((file) => ({

--- a/document-service/documents-ui/src/pages/DocumentRecords.vue
+++ b/document-service/documents-ui/src/pages/DocumentRecords.vue
@@ -13,6 +13,10 @@ const {
   searchDocumentId
 } = storeToRefs(useBcrosDocuments())
 
+const showDialog = ref(false)
+const identifier = useRoute()?.params?.identifier as string
+const docClass = useRoute()?.query?.class as string
+
 /**
  * onMounted hook to initialize document state:
  * - Disables editing mode.
@@ -33,10 +37,6 @@ onMounted(async () => {
     isLoading.value = false
   }
 })
-
-const showDialog = ref(false)
-const identifier = useRoute()?.params?.identifier as string
-const docClass = useRoute()?.query?.class as string
 
 const cancel = (forceCancel: boolean = false) => {
   if(hasDocumentRecordChanges.value && !forceCancel) {


### PR DESCRIPTION
- When the class query param is absent, the search response varies. Needed to handle that accordingly. 
- This fixes a bug that that will result in navigating to the Doc Table instead of record