### PR TITLE
DRS API patch doc type, scanning info

### DIFF
--- a/document-service/doc-api/pyproject.toml
+++ b/document-service/doc-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doc-api"
-version = "0.1.15"
+version = "0.1.16"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/document-service/doc-api/src/doc_api/models/type_tables.py
+++ b/document-service/doc-api/src/doc_api/models/type_tables.py
@@ -355,11 +355,11 @@ class DocumentTypeClass(db.Model):  # pylint: disable=too-few-public-methods
         return results
 
     @classmethod
-    def find_by_doc_type(cls, doc_type: str, all: bool = False):
+    def find_by_doc_type(cls, doc_type: str, all_classes: bool = False):
         """Return a specific set of records by type."""
         if not doc_type or doc_type not in DocumentTypes or doc_type == DocumentTypes.DELETED.value:
             return None
-        if all:
+        if all_classes:
             return db.session.query(DocumentTypeClass).filter(DocumentTypeClass.document_type == doc_type).all()
 
         return (

--- a/document-service/doc-api/src/doc_api/resources/v1/documents.py
+++ b/document-service/doc-api/src/doc_api/resources/v1/documents.py
@@ -89,6 +89,10 @@ def update_document_info(doc_service_id: str):
             RequestTypes.UPDATE, req_path, document.document_type, resource_utils.get_doc_storage_type(doc_class)
         )
         info = resource_utils.update_request_info(request, info, doc_service_id, doc_class, is_staff(jwt))
+        req_data = info.request_data
+        req_data["existingDocument"] = document.json  # Add to validate changes
+        info.request_data = req_data
+        logger.info(info.request_data)
         # Additional validation not covered by the schema.
         extra_validation_msg = resource_utils.validate_request(info)
         if extra_validation_msg != "":


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26580

*Description of changes:*
- Update PATCH /doc/api/v1/documents/{docServiceId} endpoint to add documentType to the payload.
- Allow  PATCH /doc/api/v1/documents/{docServiceId} to update/edit existing scanning record information. 
- Update validation to include scanningInformation and prevent document class changes.
