### PR TITLE
DRS API combine reports and documents in a single api call.

### DIFF
--- a/document-service/doc-api/pyproject.toml
+++ b/document-service/doc-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doc-api"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/document-service/doc-api/tests/postman/doc-api-unit.postman_collection.json
+++ b/document-service/doc-api/tests/postman/doc-api-unit.postman_collection.json
@@ -284,6 +284,55 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get By Docs and Report by Entity ID",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Account-Id",
+								"value": "{{account_id}}"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/application-reports/history/BUSINESS/BC0650000?includeDocuments=true\n",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"application-reports",
+								"history",
+								"BUSINESS",
+								"BC0650000"
+							],
+							"query": [
+								{
+									"key": "includeDocuments",
+									"value": "true\n"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"description": "Submit requests to create new document records with or without a document payload."
@@ -2719,11 +2768,11 @@
 	"variable": [
 		{
 			"key": "apikey",
-			"value": "PROVIDE"
+			"value": "provide"
 		},
 		{
 			"key": "account_id",
-			"value": "PROVIDE"
+			"value": "provide"
 		},
 		{
 			"key": "base_url_prism",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28954

*Description of changes:*
- Add option to include documents when fetching entity application reports for an product code/entity id (the filing history).
-  Add a boolean request parameter named includeDocuments to the endpoint /doc/api/v1/application-reports/history/{productCode}/{entityIdentifier}.