### PR TITLE
DRS API generic search specify from UI

### DIFF
--- a/document-service/doc-api/pyproject.toml
+++ b/document-service/doc-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "doc-api"
-version = "0.3.1"
+version = "0.3.2"
 description = ""
 authors = ["dlovett <doug@daxiom.com>"]
 license = "BSD 3"

--- a/document-service/doc-api/tests/unit/models/test_search_utils.py
+++ b/document-service/doc-api/tests/unit/models/test_search_utils.py
@@ -41,15 +41,15 @@ TEST_DATA_PAGE_SIZE = [
     (2, search_utils.SEARCH_PAGE_SIZE),
     (5, 4 * search_utils.SEARCH_PAGE_SIZE)
 ]
-# testdata pattern is ({doc_class}, {doc_type}, {start_date}, {end_date}, {cons_id}, {doc_id}, {filename})
+# testdata pattern is ({doc_class}, {doc_type}, {start_date}, {end_date}, {cons_id}, {doc_id}, {filename}, {from_ui})
 TEST_DATA_SEARCH_FILTER = [
-    (None, None, None, None, None, None, None),
-    ('PPR', None, None, None, None, None, None),
-    ('PPR', 'PPRS', None, None, None, None, None),
-    ('CORP', None, None, None, 'BC0700', None, None),
-    ('CORP', None, None, None, None, '2143', None),
-    ('SOCIETY', None, '2024-09-01', '2024-09-02', None, '2143', None),
-    ('CORP', None, None, None, None, None, 'change of add')
+    (None, None, None, None, None, None, None, True),
+    ('PPR', None, None, None, None, None, None, True),
+    ('PPR', 'PPRS', None, None, None, None, None, True),
+    ('CORP', None, None, None, 'BC0700', None, None, True),
+    ('CORP', None, None, None, None, '2143', None, True),
+    ('SOCIETY', None, '2024-09-01', '2024-09-02', None, '2143', None, True),
+    ('CORP', None, None, None, None, None, 'change of add', True)
 ]
 
 
@@ -63,8 +63,8 @@ def test_page_clause(session, page_num, expected_offset):
     assert clause == test_clause
 
 
-@pytest.mark.parametrize("doc_class,doc_type,start_dt,end_dt,cons_id,doc_id,filename", TEST_DATA_SEARCH_FILTER)
-def test_build_search_filter(session, doc_class, doc_type, start_dt, end_dt, cons_id, doc_id, filename):
+@pytest.mark.parametrize("doc_class,doc_type,start_dt,end_dt,cons_id,doc_id,filename,from_ui", TEST_DATA_SEARCH_FILTER)
+def test_build_search_filter(session, doc_class, doc_type, start_dt, end_dt, cons_id, doc_id, filename, from_ui):
     """Assert that building the search base query from search parameters works as expected."""
     req_info: RequestInfo = RequestInfo(None, None, doc_type, None)
     req_info.document_class = doc_class
@@ -73,6 +73,7 @@ def test_build_search_filter(session, doc_class, doc_type, start_dt, end_dt, con
     req_info.consumer_identifier = cons_id
     req_info.consumer_doc_id = doc_id
     req_info.consumer_filename = filename
+    req_info.from_ui = from_ui
     query: str = search_utils.build_filter_clause(req_info)
     if doc_class:
         assert query.find(' AND d.document_class = ') != -1
@@ -100,8 +101,8 @@ def test_build_search_filter(session, doc_class, doc_type, start_dt, end_dt, con
         assert query.find(' AND LOWER(d.consumer_filename) LIKE ') == -1
 
 
-@pytest.mark.parametrize("doc_class,doc_type,start_dt,end_dt,cons_id,doc_id,filename", TEST_DATA_SEARCH_FILTER)
-def test_search_count(session, doc_class, doc_type, start_dt, end_dt, cons_id, doc_id, filename):
+@pytest.mark.parametrize("doc_class,doc_type,start_dt,end_dt,cons_id,doc_id,filename,from_ui", TEST_DATA_SEARCH_FILTER)
+def test_search_count(session, doc_class, doc_type, start_dt, end_dt, cons_id, doc_id, filename, from_ui):
     """Assert that executing the search count query from search parameters works as expected."""
     req_info: RequestInfo = RequestInfo(None, None, doc_type, None)
     req_info.document_class = doc_class
@@ -110,13 +111,14 @@ def test_search_count(session, doc_class, doc_type, start_dt, end_dt, cons_id, d
     req_info.consumer_identifier = cons_id
     req_info.consumer_doc_id = doc_id
     req_info.consumer_filename = filename
+    req_info.from_ui = from_ui
     filter_clause: str = search_utils.build_filter_clause(req_info)
     search_count: int = search_utils.get_search_count(filter_clause)
     assert search_count >= 0
 
 
-@pytest.mark.parametrize("doc_class,doc_type,start_dt,end_dt,cons_id,doc_id,filename", TEST_DATA_SEARCH_FILTER)
-def test_search_docs(session, doc_class, doc_type, start_dt, end_dt, cons_id, doc_id, filename):
+@pytest.mark.parametrize("doc_class,doc_type,start_dt,end_dt,cons_id,doc_id,filename,from_ui", TEST_DATA_SEARCH_FILTER)
+def test_search_docs(session, doc_class, doc_type, start_dt, end_dt, cons_id, doc_id, filename, from_ui):
     """Assert that executing the search from search parameters works as expected."""
     req_info: RequestInfo = RequestInfo(None, None, doc_type, None)
     req_info.document_class = doc_class
@@ -125,6 +127,7 @@ def test_search_docs(session, doc_class, doc_type, start_dt, end_dt, cons_id, do
     req_info.consumer_identifier = cons_id
     req_info.consumer_doc_id = doc_id
     req_info.consumer_filename = filename
+    req_info.from_ui = from_ui
     search_results = search_utils.get_search_docs(req_info)
     assert search_results
     assert 'resultCount' in search_results

--- a/document-service/doc-api/tests/unit/resources/test_searches.py
+++ b/document-service/doc-api/tests/unit/resources/test_searches.py
@@ -98,18 +98,19 @@ TEST_SEARCH_DATA_CLASS = [
     ("Valid doc service ID", PARAM_DOC_SERVICE_ID, STAFF_ROLES, "UT1234", DOC_CLASS1, HTTPStatus.OK),
 ]
 
-# testdata pattern is ({description}, {params}, {roles}, {account}, {status})
+# testdata pattern is ({description}, {params}, {roles}, {account}, {status}, {from_ui})
 TEST_SEARCH_DATA = [
-    ("Invalid doc class", PARAM_CLASS_INVALID, STAFF_ROLES, "UT1234", HTTPStatus.BAD_REQUEST),
-    ("Invalid date params", PARAMS_DATE_INVALID, STAFF_ROLES, "UT1234", HTTPStatus.BAD_REQUEST),
-    ("Staff missing account", PARAM_CONSUMER_ID, STAFF_ROLES, None, HTTPStatus.BAD_REQUEST),
-    ("Invalid role", PARAM_CONSUMER_ID, INVALID_ROLES, "UT1234", HTTPStatus.UNAUTHORIZED),
-    ("Valid no params", None, STAFF_ROLES, "UT1234", HTTPStatus.OK),
-    ("Valid date params", PARAMS_DATE_VALID, STAFF_ROLES, "UT1234", HTTPStatus.OK),
-    ("Valid all params", PARAMS_ALL_VALID, STAFF_ROLES, "UT1234", HTTPStatus.OK),
-    ("Valid consumer ID no results", PARAM_CONSUMER_ID_NONE, STAFF_ROLES, "UT1234", HTTPStatus.OK),
-    ("Valid consumer ID", PARAM_CONSUMER_ID, STAFF_ROLES, "UT1234", HTTPStatus.OK),
-    ("Valid document ID", PARAM_CONSUMER_DOC_ID, STAFF_ROLES, "UT1234", HTTPStatus.OK)
+    ("Invalid doc class", PARAM_CLASS_INVALID, STAFF_ROLES, "UT1234", HTTPStatus.BAD_REQUEST, True),
+    ("Invalid date params", PARAMS_DATE_INVALID, STAFF_ROLES, "UT1234", HTTPStatus.BAD_REQUEST, True),
+    ("Staff missing account", PARAM_CONSUMER_ID, STAFF_ROLES, None, HTTPStatus.BAD_REQUEST, True),
+    ("Invalid role", PARAM_CONSUMER_ID, INVALID_ROLES, "UT1234", HTTPStatus.UNAUTHORIZED, True),
+    ("Valid no params", None, STAFF_ROLES, "UT1234", HTTPStatus.OK, True),
+    ("Valid date params", PARAMS_DATE_VALID, STAFF_ROLES, "UT1234", HTTPStatus.OK, True),
+    ("Valid all params", PARAMS_ALL_VALID, STAFF_ROLES, "UT1234", HTTPStatus.OK, True),
+    ("Valid consumer ID no results", PARAM_CONSUMER_ID_NONE, STAFF_ROLES, "UT1234", HTTPStatus.OK, True),
+    ("Valid consumer ID", PARAM_CONSUMER_ID, STAFF_ROLES, "UT1234", HTTPStatus.OK, True),
+    ("Valid document ID", PARAM_CONSUMER_DOC_ID, STAFF_ROLES, "UT1234", HTTPStatus.OK, True),
+    ("Valid document ID not UI", PARAM_CONSUMER_DOC_ID, STAFF_ROLES, "UT1234", HTTPStatus.OK, False)
 ]
 
 
@@ -155,8 +156,8 @@ def test_class_searches(session, client, jwt, desc, params, roles, account, doc_
             assert doc_json.get("documentClass")
 
 
-@pytest.mark.parametrize("desc,params,roles,account,status", TEST_SEARCH_DATA)
-def test_searches(session, client, jwt, desc, params, roles, account, status):
+@pytest.mark.parametrize("desc,params,roles,account,status,from_ui", TEST_SEARCH_DATA)
+def test_searches(session, client, jwt, desc, params, roles, account, status, from_ui):
     """Assert that a documents search request by any search parameter works as expected."""
     # setup
     current_app.config.update(AUTH_SVC_URL=MOCK_AUTH_URL)
@@ -168,6 +169,8 @@ def test_searches(session, client, jwt, desc, params, roles, account, status):
     req_path = GET_PATH_ANY
     if params:
         req_path += params
+        if from_ui:
+            req_path += "&fromUI=true"
 
     if status == HTTPStatus.OK and desc != "Valid consumer ID no results":  # Create.
         response = client.post(


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29112

*Description of changes:*
- Generic search endpoint GET /doc/api/v1/searches add fromUI request parameter to distinguish responses formatted for UI filtering. For UI responses, document ID's with multiple records are returned as a single item with multiple file names.