### PR TITLE
Add `fromUI` query param

### DIFF
--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcros-documents-ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/document-service/documents-ui/src/composables/useDocumentSearch.ts
+++ b/document-service/documents-ui/src/composables/useDocumentSearch.ts
@@ -93,9 +93,7 @@ export const useDocumentSearch = () => {
           documentUrls: [documentURL],
           ...rest,
         })
-      }
-
-      if (map.get(docKey)) {
+      } else {
         const existingDoc = map.get(docKey)
         if (consumerFilename) {
           existingDoc.consumerFilenames.push(consumerFilename)

--- a/document-service/documents-ui/src/utils/documentRequests.ts
+++ b/document-service/documents-ui/src/utils/documentRequests.ts
@@ -43,6 +43,8 @@ export async function getDocuments(params: DocumentRequestIF): Promise<ApiRespon
   if (queryStartDate) queryParams.append('queryStartDate', queryStartDate)
   if (queryEndDate) queryParams.append('queryEndDate', queryEndDate)
   if (pageNumber) queryParams.append('pageNumber', pageNumber.toString())
+  // if fromUI is true, a single item with multiple file names is returned for each document ID
+  queryParams.append('fromUI', String(true))
 
   // Build the full URL
   const url = `${baseURL}/searches?${queryParams.toString()}`


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29116

*Description of changes:*
– Added `fromUI` query param to the search request, specifically for the document table. 
– Fixed error in consolidating document IDs

<img width="914" alt="image" src="https://github.com/user-attachments/assets/08786329-e548-4231-9270-50dc36d40b02" />
