### PR TITLE
Potential fix for code scanning alert no. 59: Server Side Template Injection

### DIFF
--- a/report-api/src/api/services/report_service.py
+++ b/report-api/src/api/services/report_service.py
@@ -19,6 +19,7 @@ import base64
 from dateutil import parser
 from flask import url_for
 from jinja2 import Environment, FileSystemLoader, Template
+from jinja2.sandbox import SandboxedEnvironment
 from weasyprint import HTML
 from weasyprint.formatting_structure.boxes import InlineBox
 
@@ -68,7 +69,10 @@ class ReportService:
                                     generate_page_number: bool = False):
         """Create a report from a json template."""
         template_decoded = base64.b64decode(template_string).decode('utf-8')
-        template_ = Template(template_decoded, autoescape=True)
+        # Use a sandboxed environment for user-supplied templates
+        sandbox_env = SandboxedEnvironment(autoescape=True)
+        sandbox_env.filters['format_datetime'] = format_datetime
+        template_ = sandbox_env.from_string(template_decoded)
         html_out = template_.render(template_args)
         return ReportService.generate_pdf(html_out, generate_page_number)
 


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/bcros-common/security/code-scanning/59](https://github.com/bcgov/bcros-common/security/code-scanning/59)

To fix this issue, we should ensure that user-provided template strings are not rendered using the unsafe `jinja2.Template` class, which allows full template language features, including code execution. The recommended fix is to use Jinja2's `SandboxedEnvironment`, which restricts what templates can do and prevents execution of dangerous code. This can be done by creating a `SandboxedEnvironment` instance and using its `from_string` method to compile the template. Optionally, filters and settings (such as `autoescape`) should be replicated from the main environment to the sandboxed one for consistency. Update the code in `ReportService.create_report_from_template` so that it uses a sandboxed environment to compile and render the template.

The changes required are as follows:
- Import `SandboxedEnvironment` from `jinja2.sandbox`.
- Create a `SandboxedEnvironment` instance, copying over any custom filters (e.g., `format_datetime`).
- Use `sandbox_env.from_string(template_decoded)` instead of `Template(template_decoded, autoescape=True)`.

All code changes are limited to the relevant method in `report-api/src/api/services/report_service.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
