### PR TITLE
Edit Not Saving All Attached Documents

### DIFF
--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -43,6 +43,5 @@
     "happy-dom": "^14.12.0",
     "vitest": "^1.6.0",
     "vitest-environment-nuxt": "^1.0.0"
-  },
-  "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
+  }
 }

--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -43,5 +43,6 @@
     "happy-dom": "^14.12.0",
     "vitest": "^1.6.0",
     "vitest-environment-nuxt": "^1.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
 }

--- a/document-service/documents-ui/src/composables/useDocuments.ts
+++ b/document-service/documents-ui/src/composables/useDocuments.ts
@@ -317,14 +317,21 @@ export const useDocuments = () => {
 
     // Update Document Files
     if (hasDocumentFileChanges.value && !!document.size) {
-      if(!!documentRecord.value.documentServiceId && !documentRecord.value.consumerFilename) {
-        await putDocument(
+      // If the record does not have a document, the first request should use PUT. 
+      // All subsequent requests should use POST.
+      if (!!documentRecord.value.documentServiceId && documentRecord.value.consumerFilenames.length === 0) {
+        const response = await putDocument(
           {
             consumerFilename: document.name,
             documentServiceId: documentRecord.value.documentServiceId
           },
           document
         )
+
+        // Update the filing name list so that subsequent requests can be sent using POST.
+        if (response.status === 'success') {
+          documentRecord.value.consumerFilenames.push(response.data.consumerFilename)
+        }
       } else {
         await postDocument(
           {

--- a/document-service/documents-ui/src/pages/DocumentRecords.vue
+++ b/document-service/documents-ui/src/pages/DocumentRecords.vue
@@ -9,8 +9,7 @@ const {
   isEditing,
   isEditingReview,
   validateRecordEdit,
-  isError,
-  searchDocumentId
+  isError
 } = storeToRefs(useBcrosDocuments())
 
 const showDialog = ref(false)

--- a/document-service/documents-ui/src/utils/documentRequests.ts
+++ b/document-service/documents-ui/src/utils/documentRequests.ts
@@ -147,21 +147,19 @@ export async function putDocument(params: DocumentRequestIF, document: RequestDa
   // Build the full URL
   const url = `${baseURL}/documents/${documentServiceId}?${queryParams.toString()}`
 
-  try {
-    await useBcrosDocFetch<ApiResponseIF>(url, options).then((response) => {
-      return {
-        data: response.data,
-        status: response.status
-      }
-    })
-  } catch (error) {
+  return useBcrosDocFetch<ApiResponseIF>(url, options).then(response => {
+    return {
+      data: response.data.value,
+      status: response.status.value
+    }
+  }).catch(error => {
     const axiosError = error as AxiosError
     return {
       message: axiosError.message,
       status: axiosError.response?.status,
       statusText: axiosError.response?.statusText,
     }
-  }
+  })
 }
 
 /**


### PR DESCRIPTION
#29270

When there was no associated document on the record and the user uploaded multiple documents in edit mode, all the requests were sent using the PUT method. 
The first request should have been PUT, and the subsequent requests should have been POST. 
- Fixed the error in the update document function.

