### PR TITLE
30356 - Run report-api from app/src not python libraries

### DIFF
--- a/report-api/Dockerfile
+++ b/report-api/Dockerfile
@@ -20,12 +20,10 @@ COPY . /app
 WORKDIR /app
 
 RUN python3 -m pip install -r requirements.txt
-RUN python3 setup.py install
-
 
 EXPOSE 8080
 
 ENV NUM_WORKERS=3
 ENV TIMEOUT=360
 
-CMD gunicorn --bind 0.0.0.0:8080 --timeout $TIMEOUT --workers $NUM_WORKERS  wsgi:application
+CMD gunicorn --bind 0.0.0.0:8080 --timeout $TIMEOUT --workers $NUM_WORKERS --chdir /app/src wsgi:application


### PR DESCRIPTION
This way the logging is picked up