### PR TITLE
30496 - Add back weasyprint to report-api for non-existing templates

### DIFF
--- a/report-api/src/api/services/chunk_report_service.py
+++ b/report-api/src/api/services/chunk_report_service.py
@@ -34,14 +34,14 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
     """Service for generating large reports using chunk approach."""
 
     _TEMPLATE_ENV = Environment(
-        loader=FileSystemLoader("."), autoescape=True
+        loader=FileSystemLoader('.'), autoescape=True
     )
 
     @dataclass
     class ChunkInfo:
         """Chunk info for chunk report."""
 
-        mode: str = "transactions"
+        mode: str = 'transactions'
         invoice_index: int = 0
         current_chunk: int = 0
         slice_start: int = 0
@@ -58,7 +58,6 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
     @staticmethod
     def _merge_pdf_files(temp_files: List[str]) -> bytes:
         """Merge multiple PDF files into one."""
-
         # Lazy import to avoid heavy module import in worker processes
         from pikepdf import Pdf  # pylint:disable=import-outside-toplevel
 
@@ -72,7 +71,7 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
 
     @staticmethod
     def _append_pdf_bytes(pdf_content: bytes, temp_files: List[str]) -> None:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.pdf') as temp_file:
             temp_file.write(pdf_content)
             temp_files.append(temp_file.name)
 
@@ -81,17 +80,17 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
         template_name: str,
         template_vars: Dict[str, Any],
         invoice_copy: Dict[str, Any],
-        chunk_info: "ChunkReportService.ChunkInfo",
+        chunk_info: 'ChunkReportService.ChunkInfo',
     ) -> str:
         chunk_vars = template_vars.copy()
-        chunk_vars["groupedInvoices"] = [invoice_copy]
-        chunk_vars["_chunk_info"] = asdict(chunk_info)
+        chunk_vars['groupedInvoices'] = [invoice_copy]
+        chunk_vars['_chunk_info'] = asdict(chunk_info)
 
         template = ChunkReportService._TEMPLATE_ENV.get_template(
-            f"{TEMPLATE_FOLDER_PATH}/{template_name}.html"
+            f'{TEMPLATE_FOLDER_PATH}/{template_name}.html'
         )
-        bc_logo_url = url_for("static", filename="images/bcgov-logo-vert.jpg")
-        registries_url = url_for("static", filename="images/reg_logo.png")
+        bc_logo_url = url_for('static', filename='images/bcgov-logo-vert.jpg')
+        registries_url = url_for('static', filename='images/reg_logo.png')
         return template.render(
             chunk_vars, bclogoUrl=bc_logo_url, registriesurl=registries_url
         )
@@ -107,14 +106,14 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
         tasks: List[Tuple[int, str]] = []
         order_id = 0
         for invoice_index, original in enumerate(grouped_invoices, start=1):
-            txns = original.get("transactions") or []
+            txns = original.get('transactions') or []
             if not txns:
                 continue
             start = 0
             while start < len(txns):
                 end = min(start + chunk_size, len(txns))
                 invoice_copy = dict(original)
-                invoice_copy["transactions"] = txns[start:end]
+                invoice_copy['transactions'] = txns[start:end]
                 html_out = ChunkReportService._build_chunk_html(
                     template_name,
                     template_vars,
@@ -144,7 +143,7 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
         if chunk_size is None:
             chunk_size = 500  # the optimal chunk size is 500 after testing
 
-        grouped_invoices = template_vars.get("groupedInvoices", [])
+        grouped_invoices = template_vars.get('groupedInvoices', [])
         temp_files: List[str] = []
 
         # Build all chunk HTMLs ahead of time (keep order id)
@@ -169,6 +168,6 @@ class ChunkReportService:  # pylint:disable=too-few-public-methods
         result = add_page_numbers_to_pdf(template_vars, merged_pdf_without_footers, generate_page_number)
 
         current_app.logger.info(
-            "chunk_report done: chunks=%s elapsed=%.1fs", len(tasks), time.time() - overall_start_time
+            'chunk_report done: chunks=%s elapsed=%.1fs', len(tasks), time.time() - overall_start_time
         )
         return result

--- a/report-api/src/api/services/gotenberg_service.py
+++ b/report-api/src/api/services/gotenberg_service.py
@@ -17,7 +17,10 @@ class GotenbergService:
         return current_app.config.get('GOTENBERG_URL')
 
     @staticmethod
-    async def _render_pdf_bytes_worker_gotenberg_with_session(args: Tuple[str, str], session: aiohttp.ClientSession) -> bytes:
+    async def _render_pdf_bytes_worker_gotenberg_with_session(
+        args: Tuple[str, str],
+        session: aiohttp.ClientSession
+    ) -> bytes:
         """Worker used to render HTML string to PDF bytes using Gotenberg with shared session."""
         html_out = args[0]
         gc.collect()
@@ -38,7 +41,10 @@ class GotenbergService:
                 gc.collect()
                 return pdf_content
             error_text = await response.text()
-            raise Exception(f"Gotenberg conversion failed with status {response.status}: {error_text}") # pylint: disable=broad-exception-raised
+            raise Exception(  # pylint: disable=broad-exception-raised
+                f'Gotenberg conversion failed with status {response.status}: '
+                f'{error_text}'
+            )
 
     @staticmethod
     async def render_tasks_parallel_async(
@@ -69,9 +75,9 @@ class GotenbergService:
     def convert_html_to_pdf_sync(html_content: str, timeout: int = 500) -> requests.Response:
         """Convert HTML content to PDF using Gotenberg synchronously."""
         gotenberg_url = GotenbergService._get_gotenberg_url()
-        endpoint = f"{gotenberg_url}/forms/chromium/convert/html"
+        endpoint = f'{gotenberg_url}/forms/chromium/convert/html'
 
-        files = [("files", ("index.html", html_content, "text/html"))]
+        files = [('files', ('index.html', html_content, 'text/html'))]
         data = {}
 
         resp = requests.post(

--- a/report-api/src/api/services/page_info.py
+++ b/report-api/src/api/services/page_info.py
@@ -1,0 +1,38 @@
+"""Shared helpers for populating page numbers in WeasyPrint documents, get rid of the cyclic dependency."""
+
+from weasyprint.formatting_structure.boxes import InlineBox
+
+
+def populate_page_info(document):
+    """Iterate through pages and populate page number info."""
+    total_pages = len(document.pages)
+    count = 1
+    for page in document.pages:
+        populate_page_count(page._page_box, count, total_pages)  # pylint: disable=protected-access
+        count += 1
+    return document
+
+
+def populate_page_count(box, count, total):
+    """Populate page info under pageinfo tag for a single box tree."""
+    if getattr(box, 'element_tag', None):
+        if box.element_tag == 'pageinfo':
+            page_info_text = f'Page {count} of {total}'
+            if isinstance(box, InlineBox):
+                box.children[0].text = page_info_text
+                # pango_layout may not exist in some cases; guard access
+                if hasattr(box.children[0], 'pango_layout'):
+                    box.children[0].pango_layout.text = page_info_text
+            box.text = page_info_text
+    if hasattr(box, 'all_children') and box.all_children():
+        for child in box.children:
+            populate_page_count(child, count, total)
+
+
+def populate_page_info_with_offset(document, start_index: int, total_pages: int):
+    """Populate page numbers starting from a given index (1-based)."""
+    count = max(1, int(start_index))
+    for page in document.pages:
+        populate_page_count(page._page_box, count, total_pages)  # pylint: disable=protected-access
+        count += 1
+    return document

--- a/report-api/src/api/services/report_service.py
+++ b/report-api/src/api/services/report_service.py
@@ -20,10 +20,12 @@ from dateutil import parser
 from flask import url_for
 from jinja2 import Environment, FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
+from weasyprint import HTML
 
 from api.services.chunk_report_service import ChunkReportService
 from api.services.footer_service import add_page_numbers_to_pdf
 from api.services.gotenberg_service import GotenbergService
+from api.services.page_info import populate_page_count, populate_page_info
 from api.utils.util import TEMPLATE_FOLDER_PATH
 
 
@@ -122,10 +124,25 @@ class ReportService:
         template_ = sandbox_env.from_string(template_decoded)
         html_out = template_.render(template_args)
 
-        report_name = (template_args or {}).get('reportName', '')
-        return ReportService._finalize_pdf(
-            template_name=report_name,
-            template_args=template_args,
-            html_out=html_out,
-            generate_page_number=generate_page_number,
-        )
+        return ReportService.generate_pdf_weasyprint(html_out, generate_page_number)
+
+    @staticmethod
+    def generate_pdf_weasyprint(html_out, generate_page_number: bool = False):
+        """Generate pdf out of the html."""
+        html = HTML(string=html_out).render(optimize_size=('fonts', 'images',))
+        if generate_page_number:
+            html = populate_page_info(html)
+
+        return html.write_pdf()
+
+    @staticmethod
+    def populate_page_info(
+        html,
+    ):  # deprecated shim, prefer api.services.page_info.populate_page_info
+        """Shim for backward compatibility; delegates to shared helper."""
+        return populate_page_info(html)
+
+    @staticmethod
+    def populate_page_count(box, count, total):  # deprecated shim
+        """Shim for backward compatibility; delegates to shared helper."""
+        return populate_page_count(box, count, total)

--- a/report-api/src/api/services/report_service.py
+++ b/report-api/src/api/services/report_service.py
@@ -72,12 +72,16 @@ class ReportService:
                 template_args,
                 generate_page_number,
             )
-        return ReportService.generate_pdf(template_name,html_out, generate_page_number, template_args)
+        return ReportService.generate_pdf(template_name, html_out, generate_page_number, template_args)
 
     @staticmethod
-    def generate_pdf(template_name, html_out, generate_page_number: bool = False, template_args: dict = None): # pylint:disable=too-many-locals
+    def generate_pdf(
+        template_name,
+        html_out,
+        generate_page_number: bool = False,
+        template_args: dict = None
+    ):
         """Generate pdf out of the html using Gotenberg."""
-
         main_pdf_bytes = GotenbergService.convert_html_to_pdf_sync(html_out).content
 
         footer_args = dict(template_args or {})

--- a/report-api/tests/conftest.py
+++ b/report-api/tests/conftest.py
@@ -15,6 +15,7 @@
 """Common setup and fixtures for the py-test suite used by this service."""
 
 import pytest
+import requests as _req
 
 from api import create_app
 from api import jwt as _jwt
@@ -78,15 +79,13 @@ def docker_compose_files(pytestconfig):
 @pytest.fixture
 def mock_gotenberg_requests(monkeypatch):
     """Mock requests.post to simulate Gotenberg PDF generation response."""
-    import requests as _req
-    
     class MockGotenbergResponse:
         status_code = 200
         content_type = 'application/pdf'
         content = b'%PDF-1.7\n%mock_pdf_content'
-        
+
         def raise_for_status(self):
             return None
-    
+
     monkeypatch.setattr(_req, 'post', lambda *args, **kwargs: MockGotenbergResponse())
     return MockGotenbergResponse

--- a/report-api/tests/conftest.py
+++ b/report-api/tests/conftest.py
@@ -78,14 +78,55 @@ def docker_compose_files(pytestconfig):
 
 @pytest.fixture
 def mock_gotenberg_requests(monkeypatch):
-    """Mock requests.post to simulate Gotenberg PDF generation response."""
-    class MockGotenbergResponse:
+    """Mock Gotenberg PDF generation for both sync and async requests."""
+    mock_pdf_content = b"""%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Contents 4 0 R>>endobj
+4 0 obj<</Length 0>>stream\nendstream endobj
+xref
+0 5
+0000000000 65535 f
+0000000010 00000 n
+0000000047 00000 n
+0000000084 00000 n
+0000000121 00000 n
+trailer<</Size 5/Root 1 0 R>>
+startxref
+148
+%%EOF"""
+
+    class MockResponse:
         status_code = 200
-        content_type = 'application/pdf'
-        content = b'%PDF-1.7\n%mock_pdf_content'
+        content = mock_pdf_content
 
         def raise_for_status(self):
-            return None
+            pass
 
-    monkeypatch.setattr(_req, 'post', lambda *args, **kwargs: MockGotenbergResponse())
-    return MockGotenbergResponse
+    class MockAsyncResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def read(self):
+            return mock_pdf_content
+
+    class MockAsyncSession:
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            return MockAsyncResponse()
+
+    monkeypatch.setattr(_req, 'post', lambda *args, **kwargs: MockResponse())
+    monkeypatch.setattr('aiohttp.ClientSession', MockAsyncSession)
+
+    return MockResponse()

--- a/report-api/tests/unit/api/test_reports.py
+++ b/report-api/tests/unit/api/test_reports.py
@@ -21,8 +21,6 @@ Test suite for reports
 import base64
 import json
 
-import pytest
-
 from .base_test import get_claims, token_header
 from api.services import report_service
 
@@ -181,7 +179,9 @@ def _inline_tpl():
     html = '<html><body>ok</body></html>'
     return base64.b64encode(html.encode('utf-8')).decode('utf-8')
 
+
 def test_statement_grouped_invoices(client, jwt, app, monkeypatch):
+    """Test statement grouped invoices."""
     monkeypatch.setattr(
         report_service.ChunkReportService,
         '_build_chunk_html',

--- a/report-api/tests/unit/api/test_reports.py
+++ b/report-api/tests/unit/api/test_reports.py
@@ -65,7 +65,7 @@ def test_generate_report_with_invalid_template(client, jwt, app):
     assert rv.status_code == 404
 
 
-def test_generate_report_with_template(client, jwt, app, mock_gotenberg_requests):
+def test_generate_report_with_template(client, jwt, app):
     """Call to generate report with new template."""
     token = jwt.create_jwt(get_claims(app_request=app), token_header)
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}
@@ -85,7 +85,7 @@ def test_generate_report_with_template(client, jwt, app, mock_gotenberg_requests
     assert rv.content_type == 'application/pdf'
 
 
-def test_generate_report_with_page_number(client, jwt, app, mock_gotenberg_requests):
+def test_generate_report_with_page_number(client, jwt, app):
     """Call to generate report with new template."""
     token = jwt.create_jwt(get_claims(app_request=app), token_header)
     headers = {'Authorization': f'Bearer {token}', 'content-type': 'application/json'}

--- a/report-api/tests/unit/services/test_chunk_report_service.py
+++ b/report-api/tests/unit/services/test_chunk_report_service.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+"""Test chunk report service."""
 
 import types
 from api.services.chunk_report_service import ChunkReportService
@@ -19,7 +19,6 @@ from api.services.chunk_report_service import ChunkReportService
 
 def test_prepare_chunk_tasks_splits_transactions(monkeypatch):
     """Should split one invoice's transactions into multiple chunk tasks."""
-
     captured = []
 
     def fake_build_chunk_html(template_name, template_vars, invoice_copy, chunk_info):
@@ -62,7 +61,7 @@ class _DummyPdf:
 
     def save(self, buf):
         # Write bytes proportional to number of pages so len > 0
-        buf.write(b"X" * (len(self.pages) + 1))
+        buf.write(b'X' * (len(self.pages) + 1))
 
 
 def test_merge_pdf_files_merges_two_pdfs(tmp_path, monkeypatch):
@@ -90,5 +89,3 @@ def test_merge_pdf_files_merges_two_pdfs(tmp_path, monkeypatch):
     merged = ChunkReportService._merge_pdf_files([str(p1), str(p2)])
     assert isinstance(merged, (bytes, bytearray))
     assert len(merged) > 0
-
-


### PR DESCRIPTION
1. https://github.com/bcgov/entity/issues/30496
2. some lint and flake8 fix