### PR TITLE
upgrade to Node.js 24

### DIFF
--- a/.github/workflows/documents-ui-cd.yaml
+++ b/.github/workflows/documents-ui-cd.yaml
@@ -25,7 +25,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "documents-ui"
       working_directory: "./document-service/documents-ui"
-      node_version: "22"
+      node_version: "24"
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/documents-ui-ci.yaml
+++ b/.github/workflows/documents-ui-ci.yaml
@@ -10,7 +10,6 @@ defaults:
   run:
     shell: bash
     working-directory: ./document-service/documents-ui
-
 jobs:
   documents-ui-ci:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-ci.yaml@main
@@ -18,4 +17,4 @@ jobs:
       app_name: "documents-ui"
       working_directory: "./document-service/documents-ui"
       codecov_flag: "documentsui"
-      node_version: "22"
+      node_version: "24"

--- a/document-service/documents-common/layers/base/package.json
+++ b/document-service/documents-common/layers/base/package.json
@@ -2,6 +2,9 @@
   "name": "documents-common-base-layer",
   "type": "module",
   "version": "0.0.6",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground",

--- a/document-service/documents-ui/package.json
+++ b/document-service/documents-ui/package.json
@@ -2,6 +2,9 @@
   "name": "bcros-documents-ui",
   "version": "0.1.9",
   "private": true,
+  "engines": {
+    "node": ">=24"
+  },
   "type": "module",
   "scripts": {
     "build-check": "nuxt build",


### PR DESCRIPTION
Issue #: https://app.zenhub.com/workspaces/sre-team-board-654d163c6817d80016102d9a/issues/gh/bcgov/entity/32835

Description of changes:
Update engines field in package.json to require Node.js >= 24.
Update GitHub Actions CI/CD workflows to use Node 24.
Align with modern runtime standards and ensure pipeline stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).