### PR TITLE
feat: Add retry mechanism for email notifications on rate limits and server errors

### DIFF
--- a/notify-service/notify-delivery/src/notify_delivery/services/providers/gc_notify.py
+++ b/notify-service/notify-delivery/src/notify_delivery/services/providers/gc_notify.py
@@ -14,6 +14,7 @@
 """This provides send email through GC Notify Service."""
 
 import base64
+import time
 
 from flask import current_app
 from notifications_python_client import NotificationsAPIClient
@@ -31,6 +32,11 @@ logger = StructuredLogging.get_logger()
 
 class GCNotify:
     """Send notification via GC Notify service."""
+
+    # Retry configuration for rate limiting and transient errors
+    MAX_RETRIES = 3
+    RETRY_BASE_DELAY = 10  # seconds
+    RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
     def __init__(self, notification: Notification) -> None:
         """Construct object."""
@@ -84,16 +90,34 @@ class GCNotify:
 
         for recipient in recipients:
             try:
-                response = self.client.send_email_notification(
-                    email_address=recipient,
-                    template_id=self.gc_notify_template_id,
-                    personalisation=personalisation,
-                    email_reply_to_id=self.gc_notify_email_reply_to_id,
-                )
-                response_list.append(NotificationSendResponse(response_id=response["id"], recipient=recipient))
+                response = self._send_with_retry(recipient, personalisation)
+                if response:
+                    response_list.append(NotificationSendResponse(response_id=response["id"], recipient=recipient))
             except HTTPError as e:
                 logger.error(f"Error sending email to {recipient}: {e}")
             except Exception as e:
                 logger.error(f"An unexpected error occurred when sending email to {recipient}: {e}")
 
         return NotificationSendResponses(recipients=response_list)
+
+    def _send_with_retry(self, recipient: str, personalisation: dict) -> dict | None:
+        """Send email with retry on rate limit (429) and transient server errors (5xx)."""
+        for attempt in range(self.MAX_RETRIES + 1):
+            try:
+                return self.client.send_email_notification(
+                    email_address=recipient,
+                    template_id=self.gc_notify_template_id,
+                    personalisation=personalisation,
+                    email_reply_to_id=self.gc_notify_email_reply_to_id,
+                )
+            except HTTPError as e:
+                if e.status_code in self.RETRYABLE_STATUS_CODES and attempt < self.MAX_RETRIES:
+                    delay = self.RETRY_BASE_DELAY * (2**attempt)
+                    logger.warning(
+                        f"Retryable error ({e.status_code}) sending to {recipient}, retrying in {delay}s "
+                        f"(attempt {attempt + 1}/{self.MAX_RETRIES})"
+                    )
+                    time.sleep(delay)
+                else:
+                    raise
+        return None

--- a/notify-service/notify-delivery/tests/unit/services/providers/test_gc_notify.py
+++ b/notify-service/notify-delivery/tests/unit/services/providers/test_gc_notify.py
@@ -14,9 +14,10 @@
 """Test suite for GC Notify service provider."""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from flask import Flask
+from notifications_python_client.errors import HTTPError
 from notify_api.models import Notification
 from notify_api.models.content import Content as NotificationContent
 
@@ -122,3 +123,95 @@ class TestGCNotify(unittest.TestCase):
         gc_notify = GCNotify(notification)
         responses = gc_notify.send()
         self.assertEqual(len(responses.recipients), 0)
+
+    @patch("notify_delivery.services.providers.gc_notify.time.sleep")
+    @patch("notify_delivery.services.providers.gc_notify.NotificationsAPIClient")
+    def test_send_retries_on_rate_limit(self, mock_notifications_client, mock_sleep):
+        """Test that 429 rate limit errors trigger retry with backoff."""
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_response.json.return_value = {"errors": [{"error": "RateLimitError", "message": "Exceeded rate limit"}]}
+        rate_limit_error = HTTPError(response=mock_response)
+
+        mock_client = mock_notifications_client.return_value
+        mock_client.send_email_notification.side_effect = [
+            rate_limit_error,
+            rate_limit_error,
+            {"id": "success-id"},
+        ]
+
+        content = MagicMock(spec=NotificationContent)
+        content.subject = "Test Subject"
+        content.body = "Test Body"
+        content.attachments = None
+        notification = MagicMock(spec=Notification)
+        notification.recipients = "test@example.com"
+        notification.content = [content]
+
+        gc_notify = GCNotify(notification)
+        responses = gc_notify.send()
+
+        self.assertEqual(len(responses.recipients), 1)
+        self.assertEqual(responses.recipients[0].response_id, "success-id")
+        self.assertEqual(mock_client.send_email_notification.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        mock_sleep.assert_any_call(10)
+        mock_sleep.assert_any_call(20)
+
+    @patch("notify_delivery.services.providers.gc_notify.time.sleep")
+    @patch("notify_delivery.services.providers.gc_notify.NotificationsAPIClient")
+    def test_send_raises_after_max_retries(self, mock_notifications_client, mock_sleep):
+        """Test that 429 errors raise after exhausting retries."""
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_response.json.return_value = {"errors": [{"error": "RateLimitError", "message": "Exceeded rate limit"}]}
+        rate_limit_error = HTTPError(response=mock_response)
+
+        mock_client = mock_notifications_client.return_value
+        mock_client.send_email_notification.side_effect = rate_limit_error
+
+        content = MagicMock(spec=NotificationContent)
+        content.subject = "Test Subject"
+        content.body = "Test Body"
+        content.attachments = None
+        notification = MagicMock(spec=Notification)
+        notification.recipients = "test@example.com"
+        notification.content = [content]
+
+        gc_notify = GCNotify(notification)
+        responses = gc_notify.send()
+
+        self.assertEqual(len(responses.recipients), 0)
+        self.assertEqual(mock_client.send_email_notification.call_count, 4)  # 1 initial + 3 retries
+        self.assertEqual(mock_sleep.call_count, 3)
+
+    @patch("notify_delivery.services.providers.gc_notify.time.sleep")
+    @patch("notify_delivery.services.providers.gc_notify.NotificationsAPIClient")
+    def test_send_retries_on_503_server_error(self, mock_notifications_client, mock_sleep):
+        """Test that 503 server errors trigger retry with backoff."""
+        mock_response = Mock()
+        mock_response.status_code = 503
+        mock_response.json.return_value = {"errors": [{"error": "ServerError", "message": "Request failed"}]}
+        server_error = HTTPError(response=mock_response)
+
+        mock_client = mock_notifications_client.return_value
+        mock_client.send_email_notification.side_effect = [
+            server_error,
+            {"id": "success-after-503"},
+        ]
+
+        content = MagicMock(spec=NotificationContent)
+        content.subject = "Test Subject"
+        content.body = "Test Body"
+        content.attachments = None
+        notification = MagicMock(spec=Notification)
+        notification.recipients = "test@example.com"
+        notification.content = [content]
+
+        gc_notify = GCNotify(notification)
+        responses = gc_notify.send()
+
+        self.assertEqual(len(responses.recipients), 1)
+        self.assertEqual(responses.recipients[0].response_id, "success-after-503")
+        self.assertEqual(mock_client.send_email_notification.call_count, 2)
+        mock_sleep.assert_called_once_with(10)

--- a/notify-service/notify-delivery/tests/unit/services/providers/test_gc_notify_housing.py
+++ b/notify-service/notify-delivery/tests/unit/services/providers/test_gc_notify_housing.py
@@ -346,10 +346,11 @@ class TestGCNotifyHousingErrorHandling(unittest.TestCase):
         """Clean up test fixtures."""
         self.app_context.pop()
 
+    @patch("notify_delivery.services.providers.gc_notify.time.sleep")
     @patch("notify_delivery.services.providers.gc_notify_housing.NotificationsAPIClient")
     @patch("notify_delivery.services.providers.gc_notify.NotificationsAPIClient")
     def test_send_with_housing_specific_error_handling(
-        self, mock_base_notifications_client, mock_housing_notifications_client
+        self, mock_base_notifications_client, mock_housing_notifications_client, mock_sleep
     ):
         """Test error handling during send with housing-specific configuration."""
         # Arrange
@@ -370,10 +371,10 @@ class TestGCNotifyHousingErrorHandling(unittest.TestCase):
         housing_service = GCNotifyHousing(mock_notification)
         result = housing_service.send()
 
-        # Assert - should handle error gracefully
+        # Assert - should handle error gracefully after retries
         self.assertIsNotNone(result)
         self.assertEqual(len(result.recipients), 0)
-        mock_client.send_email_notification.assert_called_once()
+        self.assertEqual(mock_client.send_email_notification.call_count, 4)  # 1 initial + 3 retries
 
     @patch("notify_delivery.services.providers.gc_notify_housing.NotificationsAPIClient")
     @patch("notify_delivery.services.providers.gc_notify.NotificationsAPIClient")


### PR DESCRIPTION
Handle the following errors:
<img width="1293" height="318" alt="image" src="https://github.com/user-attachments/assets/4ae21543-b3ff-4843-98d0-20f2484da756" />

<img width="2221" height="309" alt="image" src="https://github.com/user-attachments/assets/79a5acc6-2b27-4d46-b14b-529beb289b6f" />
