### PR TITLE
fix: Update Dockerfile to use 'bookworm' variant and apply security patch

### DIFF
--- a/notify-service/notify-delivery/Dockerfile
+++ b/notify-service/notify-delivery/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bullseye AS builder
+FROM python:3.12-bookworm AS builder
 
 USER root
 
@@ -73,7 +73,7 @@ COPY --chown=web:web ./wsgi.py /code/
 COPY --chown=web:web ./gunicorn_config.py /code/
 COPY --chown=web:web ./devops /code/devops
 
-FROM python:3.12-slim-bullseye AS production
+FROM python:3.12-slim-bookworm AS production
 
 USER root
 
@@ -88,10 +88,12 @@ ENV PORT=8080 \
   PYTHONHASHSEED=random \
   PYTHONDONTWRITEBYTECODE=1
 
-# Install only runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Apply latest security patches and install only runtime dependencies
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
   libpq5 \
-  curl \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g "${GID}" -r web \


### PR DESCRIPTION
…atches
This pull request updates the Dockerfile for the `notify-delivery` service to use the newer Debian Bookworm base image and improves security by ensuring the latest patches are applied during build. The changes also optimize the installation of runtime dependencies.

**Base image updates:**

* Switched the base images from Debian Bullseye to Debian Bookworm for both the build and production stages in the `Dockerfile`, ensuring access to newer system libraries and security updates. [[1]](diffhunk://#diff-0edb674db9398eb032fcbe5c419c41633c5b301b38ce905c18d78ea0bf96c02bL1-R1) [[2]](diffhunk://#diff-0edb674db9398eb032fcbe5c419c41633c5b301b38ce905c18d78ea0bf96c02bL76-R76)

**Security and dependency management:**

* Added an `apt-get upgrade -y` step during build to apply the latest security patches, and optimized the installation of runtime dependencies by purging unnecessary packages and cleaning up after installation.