### PR TITLE
Enhance Dockerfile instructions and add usage examples

### DIFF
--- a/notify-service/notify-api/Dockerfile
+++ b/notify-service/notify-api/Dockerfile
@@ -1,3 +1,12 @@
+# Multi-stage Dockerfile for notify-api service
+# Builds two distinct images:
+#   - runtime: Production-grade distroless image for running the API service
+#   - migration: Full Python environment for running database migrations
+#
+# Build commands:
+#   docker build --target runtime -t notify-api .
+#   docker build --target migration -t notify-api-migrations .
+
 FROM python:3.13-slim-trixie AS builder
 
 USER root
@@ -72,14 +81,12 @@ COPY --chown=65532:65532 ./migrations /code/migrations
 RUN chown -R 65532:65532 /code/.venv
 
 # ---------------------------------------------------------------------------
-# Runtime: Google distroless. No shell, no package manager, no pip.
+# TARGET: runtime
+# Production-grade distroless image. No shell, no package manager, no pip.
 # Default ENTRYPOINT is /usr/bin/python; we override to launch gunicorn as a module.
 # Image already runs as the 'nonroot' user (UID/GID 65532) via the :nonroot tag.
-#
-# NOTE: update_db.sh / `flask db upgrade` cannot run from this image (no shell,
-# no uv). Run DB migrations from a separate, non-distroless image or job.
 # ---------------------------------------------------------------------------
-FROM gcr.io/distroless/python3-debian13:nonroot AS production
+FROM gcr.io/distroless/python3-debian13:nonroot AS runtime
 
 ARG VCS_REF="missing"
 ARG BUILD_DATE="missing"
@@ -107,3 +114,54 @@ USER 65532:65532
 
 # Bind is sourced from the PORT env var inside gunicorn_config.py.
 ENTRYPOINT ["python", "-m", "gunicorn", "-c", "/code/gunicorn_config.py", "wsgi:app"]
+
+# ---------------------------------------------------------------------------
+# TARGET: migration
+# Full Python environment with shell and tools for running database migrations.
+# This image is designed for one-off migration jobs, not long-lived services.
+# ---------------------------------------------------------------------------
+FROM python:3.13-slim-trixie AS migration
+
+ARG VCS_REF="missing"
+ARG BUILD_DATE="missing"
+
+LABEL org.label-schema.vcs-ref=${VCS_REF} \
+  org.label-schema.build-date=${BUILD_DATE} \
+  vendor="BCROS"
+
+ENV DEPLOYMENT_ENV=migration \
+  PYTHONFAULTHANDLER=1 \
+  PYTHONUNBUFFERED=1 \
+  PYTHONHASHSEED=random \
+  PYTHONDONTWRITEBYTECODE=1 \
+  # uv:
+  UV_HOME="/usr/local" \
+  PATH="/usr/local/bin:/root/.local/bin:$PATH" \
+  PYTHONPATH="/code/src:/code/.venv/lib/python3.13/site-packages"
+
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+# Install required system dependencies
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install --no-install-recommends -y \
+  ca-certificates \
+  curl \
+  git \
+  && curl -LsSf https://astral.sh/uv/install.sh | sh \
+  && mv /root/.local/bin/uv /usr/local/bin/uv \
+  # Cleaning cache:
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code
+
+# Copy the entire application from builder
+COPY --from=builder /code /code
+
+# Create a non-root user for running migrations
+RUN useradd -m -u 1000 migrator && chown -R migrator:migrator /code
+
+USER migrator
+
+# Default entrypoint runs flask db upgrade
+ENTRYPOINT ["uv", "run", "flask", "db", "upgrade"]

--- a/notify-service/notify-api/README.md
+++ b/notify-service/notify-api/README.md
@@ -116,17 +116,46 @@ uv run python -m pytest tests/unit/models/ -v --no-cov
 
 ## Docker
 
-Build from `notify-api/Dockerfile` using explicit targets:
+Build from `notify-api/Dockerfile` using explicit targets.
+
+> **Important:** When building on Apple Silicon (M1/M2/M3) or any ARM host
+> for deployment to Cloud Run / GKE / x86 infrastructure, always pass
+> `--platform linux/amd64`. Cloud Run rejects `arm64` images with
+> `terminated: Application failed to start: The container may have exited
+> abnormally.`
 
 ```bash
-# Build API runtime image (distroless)
+# Build API runtime image (distroless) for the local host architecture
 docker build --target runtime -t notify-api .
 
-# Build migration job image
+# Build migration job image for the local host architecture
 docker build --target migration -t notify-api-migrations .
+
+# Build explicitly for linux/amd64 (required for Cloud Run from ARM Macs)
+docker build --platform linux/amd64 --target runtime -t notify-api .
+docker build --platform linux/amd64 --target migration -t notify-api-migrations .
 ```
 
-Run images:
+Push to Artifact Registry (example for the BC Gov `c4hnrd-tools` project):
+
+```bash
+# Authenticate Docker/Podman with Artifact Registry
+gcloud auth print-access-token | \
+  docker login -u oauth2accesstoken --password-stdin \
+  https://northamerica-northeast1-docker.pkg.dev
+
+# Build & tag for amd64, then push
+IMAGE="northamerica-northeast1-docker.pkg.dev/c4hnrd-tools/cloud-run-repo/notify-api-migrations"
+TAG=$(date +%Y%m%d-%H%M%S)
+
+docker build --platform linux/amd64 --target migration \
+  -t "${IMAGE}:latest" -t "${IMAGE}:${TAG}" .
+
+docker push "${IMAGE}:${TAG}"
+docker push "${IMAGE}:latest"
+```
+
+Run images locally:
 
 ```bash
 # Run API container

--- a/notify-service/notify-api/README.md
+++ b/notify-service/notify-api/README.md
@@ -24,7 +24,7 @@ This application follows BC Government security standards and best practices.
 
 ## Files in this repository
 
-```
+```text
 notify-api/
 ├── src/notify_api/          # Main application code
 ├── tests/                   # Test suite

--- a/notify-service/notify-api/README.md
+++ b/notify-service/notify-api/README.md
@@ -114,6 +114,36 @@ uv run python -m pytest tests/unit/models/ -v --no-cov
 .././run_local.sh
 ```
 
+## Docker
+
+Build from `notify-api/Dockerfile` using explicit targets:
+
+```bash
+# Build API runtime image (distroless)
+docker build --target runtime -t notify-api .
+
+# Build migration job image
+docker build --target migration -t notify-api-migrations .
+```
+
+Run images:
+
+```bash
+# Run API container
+docker run --rm -p 8080:8080 notify-api
+
+# Run database migrations (one-off job)
+docker run --rm \
+  -e DEPLOYMENT_ENV=migration \
+  -e DB_HOST=<db-host> \
+  -e DB_PORT=<db-port> \
+  -e DB_USER=<db-user> \
+  -e DB_PASSWORD=<db-password> \
+  -e DB_NAME=<db-name> \
+  -e DB_SCHEMA=<db-schema> \
+  notify-api-migrations
+```
+
 ## Database Operations
 
 ### Running Database Migrations

--- a/notify-service/notify-api/pyproject.toml
+++ b/notify-service/notify-api/pyproject.toml
@@ -139,6 +139,7 @@ ignore = [
     "N999",
     "PLR6301", #
     "PLC0415", # `import` should be at the top-level of a file
+    "PLW0717", # try-statement-too-long (preview); existing try blocks intentionally group related ops
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
**Dockerfile refactor and image separation:**

* Refactored `notify-api/Dockerfile` into a multi-stage build that produces two separate images:
  - `runtime`: A minimal, production-grade distroless image for running the API.
  - [`migration`]: A full Python environment image with shell and tools for running database migrations. 

**Documentation improvements:**

* Updated `notify-api/README.md` with detailed instructions for building, tagging, pushing, and running both images, including platform-specific notes for ARM and x86 compatibility and deployment to Google Cloud Run.