### PR TITLE
fix: pin pnpm_version to 11.9.0 in documents-ui-cd (was latest-11)

### DIFF
--- a/.github/workflows/documents-ui-cd.yaml
+++ b/.github/workflows/documents-ui-cd.yaml
@@ -32,7 +32,7 @@ jobs:
       target: ${{ inputs.target }}
       app_name: "documents-ui"
       working_directory: "./document-service/documents-ui"
-      pnpm_version: latest-11
+      pnpm_version: 11.9.0
       node_version: "24"
     secrets:
       WORKLOAD_IDENTIFY_POOLS_PROVIDER: ${{ secrets.WORKLOAD_IDENTIFY_POOLS_PROVIDER }}

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: latest-11
+          version: 11.9.0
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Follow-up to #282. `documents-ui-cd.yaml` (the live deploy workflow) and the leftover `test-pnpm-v11.yml` smoke test were still using `pnpm_version: latest-11`, a floating tag that resolves to whatever the newest 11.x patch is at build time.

This already caused a real failure elsewhere in the org-wide pnpm v11 migration when `latest-11` moved to `11.12.0` and hit a `pnpm/action-setup` self-install bug (`Cannot use 'in' operator to search for 'integrity' in undefined`). Pinning to `11.9.0` for a stable, reproducible deploy.