### PR TITLE
DRS API business ledger docs exclude if no filing ID.

### DIFF
--- a/document-service/doc-api/src/doc_api/resources/v1/application_reports.py
+++ b/document-service/doc-api/src/doc_api/resources/v1/application_reports.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """API endpoints for requests to maintain application reports."""
+import copy
 import io
 import zipfile
 from http import HTTPStatus
@@ -280,7 +281,8 @@ def get_product_history_reports(prod_code: str, entity_id: str):
         if extra_validation_msg != "":
             return resource_utils.extra_validation_error_response(extra_validation_msg)
         reports_json: list = ApplicationReport.find_by_entity_id_json(entity_id, prod_code)
-        reports_json = add_documents(request, entity_id, reports_json)
+        if is_include_docs_request(request.args.get("includeDocuments")):
+            reports_json = add_documents(entity_id, reports_json)
         if not reports_json:
             logger.warning(f"No {prod_code} report records found for entity id={entity_id}.")
             return resource_utils.not_found_error_response(
@@ -434,10 +436,12 @@ def get_new_report_params(req: request, request_json: dict) -> dict:
     return request_json
 
 
-def add_documents(req: request, entity_id: str, reports_json: list) -> list:
-    """Conditionally include documents to the entity identifier filing history request."""
-    if not req.args.get("includeDocuments", False):
-        return reports_json
+def add_documents(entity_id: str, reports_json: list) -> list:
+    """
+    Conditionally include documents to the entity identifier filing history request. Only include documents
+    that have an event identifier which may or may not match one of the report event identifiers. For pre DRS
+    integration filings that are not colin migration, a filing report may not yet exist in the DRS.
+    """
     docs_json = Document.find_history_by_consumer_id(entity_id)
     if not docs_json:
         return reports_json
@@ -450,13 +454,14 @@ def add_documents(req: request, entity_id: str, reports_json: list) -> list:
             all_json.append(rep)
         else:
             event_id = rep.get("eventIdentifier")
+            all_json.append(rep)
             for doc in docs_json:
                 if doc.get("eventIdentifier") and doc.get("eventIdentifier") == event_id:
-                    all_json.append(doc)
-            all_json.append(rep)
-    # Append orphaned docs (no event ID)
+                    all_json.append(copy.deepcopy(doc))
+                    doc["added"] = True
+    # Now add documents that have event identifiers that do not match any filing report event identifiers.
     for doc in docs_json:
-        if not doc.get("eventIdentifier") or doc.get("eventIdentifier") < 1:
+        if doc.get("eventIdentifier") and doc.get("eventIdentifier") > 1 and not doc.get("added", False):
             all_json.append(doc)
     return all_json
 

--- a/document-service/doc-api/tests/unit/resources/test_application_reports.py
+++ b/document-service/doc-api/tests/unit/resources/test_application_reports.py
@@ -25,12 +25,13 @@ from flask import current_app
 from doc_api.models import ApplicationReport, Document
 from doc_api.models import utils as model_utils
 from doc_api.resources.v1.application_reports import (
-    build_event_zip, get_zip_filename,
+    add_documents,
+    build_event_zip,
+    get_zip_filename,
     is_certified_copy_report_type,
     is_certified_copy_request
 )
 from doc_api.services.authz import BC_REGISTRY, COLIN_ROLE, STAFF_ROLE, SYSTEM_ROLE
-from doc_api.services.document_storage.storage_service import GoogleStorageService
 from doc_api.utils.logging import logger
 from tests.unit.services.utils import (
     create_header_account,
@@ -139,6 +140,71 @@ CC_FILING_INFILE = "tests/unit/reports/data/filing.pdf"
 CC_FILING_OUTFILE = "tests/unit/resources/filing-certified.pdf"
 CC_FILING_AR_LEGACY_INFILE = "tests/unit/reports/data/legacy-conv-ar-filing.pdf"
 CC_FILING_AR_LEGACY_OUTFILE = "tests/unit/reports/data/legacy-conv-ar-certified.pdf"
+REPORTS_TEST1 = [
+  {
+    "dateCreated": "2026-07-22T18:45:06+00:00",
+    "datePublished": "2026-07-22T19:00:00+00:00",
+    "entityIdentifier": "CP1044806",
+    "eventIdentifier": 3671078,
+    "identifier": "DSR0000105896",
+    "reportType": "FILING-2",
+  },
+  {
+    "dateCreated": "2026-07-22T18:45:42+00:00",
+    "datePublished": "2026-07-22T19:00:00+00:00",
+    "entityIdentifier": "CP1044806",
+    "eventIdentifier": 3671078,
+    "identifier": "DSR0000105898",
+    "reportType": "CERT",
+  },
+  {
+    "dateCreated": "2026-07-22T18:45:06+00:00",
+    "datePublished": "2026-07-22T19:00:00+00:00",
+    "entityIdentifier": "CP1044806",
+    "eventIdentifier": 3671078,
+    "identifier": "DSR0000105897",
+    "reportType": "FILING",
+  }
+]
+DOCS_TEST1 = {
+    "consumerDocumentId": "T0000001",
+    "consumerFilename": "test.pdf",
+    "consumerIdentifier": "CP1044806",
+    "documentClass": "COOP",
+    "documentType": "COSD",
+    "consumerFilingDateTime": "2024-07-01T19:00:00+00:00",
+    "consumerReferenceId": "3671078",
+    "documentServiceId": "DS9000102019",
+}
+DOCS_TEST2 = {
+    "consumerDocumentId": "T0000001",
+    "consumerFilename": "test.pdf",
+    "consumerIdentifier": "CP1044806",
+    "documentClass": "COOP",
+    "documentType": "COSD",
+    "consumerFilingDateTime": "2024-07-01T19:00:00+00:00",
+    "consumerReferenceId": "",
+    "documentServiceId": "DS9000102019",
+}
+DOCS_TEST3 = {
+    "consumerDocumentId": "T0000001",
+    "consumerFilename": "test.pdf",
+    "consumerIdentifier": "CP1044806",
+    "documentClass": "COOP",
+    "documentType": "COSD",
+    "consumerFilingDateTime": "2024-07-01T19:00:00+00:00",
+    "documentServiceId": "DS9000102019",
+}
+DOCS_TEST4 = {
+    "consumerDocumentId": "T0000001",
+    "consumerFilename": "test.pdf",
+    "consumerIdentifier": "CP1044806",
+    "documentClass": "COOP",
+    "documentType": "COSD",
+    "consumerFilingDateTime": "2024-07-01T19:00:00+00:00",
+    "consumerReferenceId": "4671078",
+    "documentServiceId": "DS9000102019",
+}
 
 # testdata pattern is ({description}, {entity_id}, {event_id}, {rtype}, {status})
 TEST_CREATE_DATA = [
@@ -302,6 +368,15 @@ TEST_GET_EVENT_DATA_PRODUCT_ALL = [
     ("Invalid role", "UT-123456", "123456", REPORT_TYPES_ZIP, HTTPStatus.UNAUTHORIZED, "BUSINESS", USER_ROLES, PAYLOAD_EMPTY, ""),
     ("Invalid product code", "UT-123456", REPORT_TYPES_ZIP, "FILING", HTTPStatus.BAD_REQUEST, "XXX", PRODUCT_ROLES_SYSTEM, PAYLOAD_EMPTY, ""),
 ]
+# testdata pattern is ({description}, {doc_added}, {report_list}, {doc}, {list_length}, {drs_id})
+TEST_ADD_DOC_DATA = [
+    ("No docs", False, REPORTS_TEST1, None, 3, "DS0000102019", "CP1044806"),
+    ("Valid doc", True, REPORTS_TEST1, DOCS_TEST1, 4, "DS0000102019", "CP1044806"),
+    ("Event ID 0 doc", False, REPORTS_TEST1, DOCS_TEST2, 3, "DS0000102019", "CP1044806"),
+    ("No event ID doc", False, REPORTS_TEST1, DOCS_TEST3, 3, "DS0000102019", "CP1044806"),
+    ("Different event ID doc", True, REPORTS_TEST1, DOCS_TEST4, 4, "DS0000102019", "CP1044806"),
+]
+
 
 
 @pytest.mark.parametrize("desc,entity_id,event_id,report_type,status,prod_code,roles", TEST_CREATE_DATA_PRODUCT)
@@ -855,6 +930,23 @@ def test_zip_filename(session, client, jwt, desc, request_data, app_rep_type, ap
         app_rep_json["documentType"] = app_doc_type
     test_filename = get_zip_filename(request_data, app_rep_json)
     assert test_filename == filename
+
+
+@pytest.mark.parametrize("desc,doc_added,report_list,doc,list_length,drs_id, entity_id", TEST_ADD_DOC_DATA)
+def test_report_add_documents(session, client, jwt, desc, doc_added, report_list, doc, list_length, drs_id, entity_id):
+    """Assert adding documents to application reports works as expected."""
+    if doc:
+        save_doc: Document = Document.create_from_json(doc, doc.get("documentType"))
+        save_doc.document_service_id = drs_id
+        save_doc.save()
+    test_list = add_documents(entity_id, report_list)
+    assert len(test_list) == list_length
+    found_doc: bool = False
+    for test_doc in test_list:
+        if test_doc.get("identifier") == drs_id:
+            found_doc = True
+            break
+    assert found_doc == doc_added
 
 
 def test_build_event_zip(session, client, jwt):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34471

*Description of changes:*
- Do not include client/scanned documents with no filing ID when fetching application reports for a business identifier and including documents.